### PR TITLE
make metric configurable that triggers checkpoint writing

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -37,6 +37,7 @@ training: # specify training details here
     validation_freq: 50  # validate after this many updates (number of mini-batches), default: 1000
     logging_freq: 10  # log the training progress after this many updates, default: 100
     eval_metric: "bleu" # validation metric, default: "bleu", other options: "chrf", "token_accuracy", "sequence_accuracy"
+    ckpt_metric: "eval_metric"  # when a new high score on this metric is achieved, a checkpoint is written, when "eval_metric" (default) is maximized, when "loss" or "ppl" is minimized
     model_dir: "my_model" # directory where models and validation results are stored, required
     overwrite: True # overwrite existing model directory, default: False. Do not set to True unless for debugging!
     shuffle: True # shuffle the training data, default: True


### PR DESCRIPTION
Introducing a third configurable metric:

1. `eval_metric`: validation metrics like BLEU or ChrF; measured on the validation set only
2. `schedule_metric`: decides when the scheduler decreases the learning rate or stops learning; might be `loss` or `ppl`, might not match `eval_metric` (since often smoother curve)
3. _new_: `ckpt_metric`: decides when the model parameters are saved, i.e., a checkpoint is written; default is  `eval_metric`

Before, checkpoint saving was coupled to `eval_metric` (new default), but potentially not matching `schedule_metric` (e.g., validating models with BLEU and storing when highest reached, but adapting learning rate according to loss). Now, one can decide whether all three align or are individually set.