### PR TITLE
increasing effective batch size through batch_multiplier option

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -29,6 +29,7 @@ training: # specify training details here
     #clip_grad_norm: 1.0  # norm clipping instead of value clipping
     weight_decay: 0.1 # l2 regularization, default: 0
     batch_size: 10  # mini-batch size, required
+    batch_multiplier: 1 # increase the effective batch size with values >1 to batch_multiplier*batch_size without increasing memory consumption by making updates only every batch_multiplier batches
     scheduling: "plateau" # learning rate scheduling, optional, if not specified stays constant, options: "plateau", "exponential", "decaying"
     patience: 5 # specific to plateau scheduler: wait for this many validations without improvement before decreasing the learning rate
     decrease_factor: 0.5  # specific to plateau & exponential scheduler: decrease the learning rate by this factor


### PR DESCRIPTION
Implementation of the ["batch_multiplier" trick](https://medium.com/@davidlmorton/increasing-mini-batch-size-without-increasing-memory-6794e10db672): making updates only every `batch_multiplier` batches, we can increase the effective batch size without increasing the memory consumption. 
