### PR TITLE
Testing after training should use best model

### DIFF
--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -489,6 +489,7 @@ def train(cfg_file):
     trainer.train_and_validate(train_data=train_data, valid_data=dev_data)
 
     if test_data is not None:
+        trainer.load_checkpoint("{}/{}.ckpt".format(trainer.model_dir, trainer.best_ckpt_iteration))
         # test model
         if "testing" in cfg.keys():
             beam_size = cfg["testing"].get("beam_size", 0)


### PR DESCRIPTION
After training, evaluation is being done on the test data (if given).

For that evaluation, the current model is used, even if a better one existed during training. During normal testing however, the best model will be used when no other path is given (because that will be the latest model in the directory). This pull request hopefully fixes the difference.