### PR TITLE
checking if checkpoint exists before loading

### DIFF
--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -7,7 +7,7 @@ import glob
 import os
 import os.path
 from logging import Logger
-from typing import Callable
+from typing import Callable, Optional
 import numpy as np
 import yaml
 
@@ -145,16 +145,19 @@ def store_attention_plots(attentions, targets, sources, output_prefix,
             continue
 
 
-def get_latest_checkpoint(ckpt_dir):
+def get_latest_checkpoint(ckpt_dir: str) -> Optional[str]:
     """
     Returns the latest checkpoint (by time) from the given directory.
+    If there is no checkpoint in this directory, returns None
 
     :param ckpt_dir:
-    :return:
+    :return: latest checkpoint file
     """
     list_of_files = glob.glob("{}/*.ckpt".format(ckpt_dir))
-    latest_file = max(list_of_files, key=os.path.getctime)
-    return latest_file
+    latest_checkpoint = None
+    if list_of_files:
+        latest_checkpoint = max(list_of_files, key=os.path.getctime)
+    return latest_checkpoint
 
 
 def load_model_from_checkpoint(path, use_cuda=True):
@@ -169,6 +172,7 @@ def load_model_from_checkpoint(path, use_cuda=True):
     model_checkpoint = torch.load(path,
                                   map_location='cuda' if use_cuda else 'cpu')
     return model_checkpoint
+
 
 # from onmt
 def tile(x, count, dim=0):

--- a/joeynmt/prediction.py
+++ b/joeynmt/prediction.py
@@ -161,6 +161,9 @@ def test(cfg_file,
     if ckpt is None:
         model_dir = cfg["training"]["model_dir"]
         ckpt = get_latest_checkpoint(model_dir)
+        if ckpt is None:
+            raise FileNotFoundError("No checkpoint found in directory {}."
+                                    .format(model_dir))
         try:
             step = ckpt.split(model_dir+"/")[1].split(".ckpt")[0]
         except IndexError:

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -496,8 +496,20 @@ def train(cfg_file):
     trainer.train_and_validate(train_data=train_data, valid_data=dev_data)
 
     if test_data is not None:
-        trainer.load_checkpoint("{}/{}.ckpt".format(
-            trainer.model_dir, trainer.best_ckpt_iteration))
+        checkpoint_path = "{}/{}.ckpt".format(
+                trainer.model_dir, trainer.best_ckpt_iteration)
+        try:
+            trainer.load_checkpoint(checkpoint_path)
+        except AssertionError:
+            trainer.logger.warning("Checkpoint %s does not exist. "
+                                   "Skipping testing.", checkpoint_path)
+            if trainer.best_ckpt_iteration == 0 \
+                and trainer.best_ckpt_score in [np.inf, -np.inf]:
+                trainer.logger.warning(
+                    "It seems like no checkpoint was written, "
+                    "since no improvement was obtained over the initial model.")
+            return
+
         # test model
         if "testing" in cfg.keys():
             beam_size = cfg["testing"].get("beam_size", 0)


### PR DESCRIPTION
Addressing #23 for training and testing. Testing is skipped after training when the checkpoint doesn't exist and the user is warned that no checkpoint might have been written since no improvement was obtained. During testing the code raises an exception when trying to load a non-existing checkpoint.