### PR TITLE
More unit tests; bridge and checkpoint handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Joey NMT is built on [PyTorch](https://pytorch.org/) v.0.4.1 and [torchtext](htt
 
 ## Usage
 Models are specified in configuration files, in simple [YAML](http://yaml.org/) format. You can find examples in the `configs` directory.
+`default.yaml` contains a detailed explanation of configuration options.
 
 ## Documentation
 Read [the docs](https://joeynmt.readthedocs.io).
@@ -141,32 +142,33 @@ We compare against the baseline scores reported in [(Wiseman & Rush, 2016)](http
 [(Bahdanau et al., 2017)](https://arxiv.org/pdf/1607.07086.pdf) (B17) with tokenized, lowercased BLEU (using `sacrebleu`).
 Ẁe compare a word-based model of the same size and vocabulary as in W&R and B17.
 The [script](https://github.com/harvardnlp/BSO/blob/master/data_prep/MT/prepareData.sh) to obtain and pre-process the data is the one published with W&R.
+Use `configs/iwslt_deen_bahdanau.yaml` for training the model.
 On a K40-GPU word-level training took <1h, beam search decoding for both dev and test <2min.
 
-Systems | level | dev | test | #params | Joey NMT config
---- | :---: | :---: | :---: | :---: | :---:
+Systems | level | dev | test | #params 
+--- | :---: | :---: | :---: | :---: 
 W&R (greedy)   | word | - | 22.53  |  
 W&R (beam=10)  | word | - | 23.87  |
 B17 (greedy)   | word | -| 25.82  |
 B17 (beam=10)  | word | -| 27.56  | 
-Joey NMT (greedy) | word | 28.41 | 26.68 | 22.05M |
-Joey NMT (beam=10, alpha=1.0) | word | 28.96 | 27.03| 22.05M | 
+Joey NMT (greedy) | word | 28.41 | 26.68 | 22.05M 
+Joey NMT (beam=10, alpha=1.0) | word | 28.96 | 27.03| 22.05M 
 
 On CPU (`use_cuda: False`): 
 (approx 8-10x slower: 8h for training, beam search decoding for both dev and test 19min, greedy decoding 5min)
 
-Systems | level | dev | test | #params | Joey NMT config
---- | :---: | :---: | :---: | :---: | :---:
-Joey NMT (greedy) | word | 28.35 | 26.46 | 22.05M |
-Joey NMT (beam=10, alpha=1.0) | word | 28.85 | 27.06 | 22.05M | 
+Systems | level | dev | test | #params 
+--- | :---: | :---: | :---: | :---: 
+Joey NMT (greedy) | word | 28.35 | 26.46 | 22.05M 
+Joey NMT (beam=10, alpha=1.0) | word | 28.85 | 27.06 | 22.05M  
 
 In addition, we compare to a BPE-based GRU model with 32k (Groundhog style). 
 Use `scripts/get_iwslt14_bpe.sh` to pre-process the data and `configs/iwslt14_deen_bpe.yaml` to train the model.
 
-Systems | level | dev | test | #params | Joey NMT config
---- | :---: | :---: | :---: | :---: | :---:  
-Joey NMT (greedy) | bpe | 27.8 | | 60.68M | 
-Joey NMT (beam=5, alpha=1.0) | bpe | 28.74 | 27.63 | 60.68M |
+Systems | level | dev | test | #params 
+--- | :---: | :---: | :---: | :---: 
+Joey NMT (greedy) | bpe | 27.8 | | 60.68M 
+Joey NMT (beam=5, alpha=1.0) | bpe | 28.74 | 27.63 | 60.68M 
 
 ## WMT 17 English-German and Latvian-English
 We compare against the results for recurrent BPE-based models that were reported in the [Sockeye paper](https://arxiv.org/pdf/1712.05690.pdf). 
@@ -178,24 +180,24 @@ Note that the scores reported for other models might not reflect the current sta
 Please also consider the difference in number of parameters despite "the same" setup: our models are the smallest in numbers of parameters.
 
 ### English-German
-Groundhog setting: `encoder rnn=500`, `lr=0.0003`, `init_hidden="bridge"`
+Groundhog setting: `configs/wmt_ende_default.yaml`  with `encoder rnn=500`, `lr=0.0003`, `init_hidden="bridge"`.
 
-Systems | level | dev | test | #params | Joey NMT config
---- | :---: | :---: | :---: | :---: | :---:  
-Sockeye (beam=5) | bpe | - | 23.18 | 87.83M | 
-OpenNMT-Py (beam=5) | bpe | - | 18.66 | 87.62M |
-Joey NMT (beam=5) | bpe | 24.33 | 23.45  | 86.37M | `configs/wmt_ende_default.yaml`  
+Systems | level | dev | test | #params 
+--- | :---: | :---: | :---: | :---: | 
+Sockeye (beam=5) | bpe | - | 23.18 | 87.83M 
+OpenNMT-Py (beam=5) | bpe | - | 18.66 | 87.62M 
+Joey NMT (beam=5) | bpe | 24.33 | 23.45  | 86.37M  
 
 The Joey NMT model was trained for 4 days (14 epochs).
 
 ### Latvian-English
-Groundhog setting: `encoder rnn=500`, `lr=0.0003`, `init_hidden="bridge"`
+Groundhog setting: `configs/wmt_lven_default.yaml` with `encoder rnn=500`, `lr=0.0003`, `init_hidden="bridge"`.
 
-Systems | level | dev | test | #params | Joey NMT config
---- | :---: | :---: | :---: | :---: | :---:  
-Sockeye (beam=5) | bpe | - | 14.40 | ? | 
-OpenNMT-Py (beam=5) | bpe | - | 9.98 | ? | 
-Joey NMT (beam=5) | bpe | 12.09 | 8.75 | 64.52M | `configs/wmt_lven_default.yaml`  
+Systems | level | dev | test | #params 
+--- | :---: | :---: | :---: | :---: 
+Sockeye (beam=5) | bpe | - | 14.40 | ? 
+OpenNMT-Py (beam=5) | bpe | - | 9.98 | ? 
+Joey NMT (beam=5) | bpe | 12.09 | 8.75 | 64.52M 
 
 
 ## Contributing

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -34,8 +34,8 @@ training: # specify training details here
     scheduling: "plateau" # learning rate scheduling, optional, if not specified stays constant, options: "plateau", "exponential", "decaying"
     patience: 5 # specific to plateau scheduler: wait for this many validations without improvement before decreasing the learning rate
     decrease_factor: 0.5  # specific to plateau & exponential scheduler: decrease the learning rate by this factor
-    epochs: 2  # train for this many epochs
-    validation_freq: 50  # validate after this many updates (number of mini-batches), default: 1000
+    epochs: 5  # train for this many epochs
+    validation_freq: 10  # validate after this many updates (number of mini-batches), default: 1000
     logging_freq: 10  # log the training progress after this many updates, default: 100
     eval_metric: "bleu" # validation metric, default: "bleu", other options: "chrf", "token_accuracy", "sequence_accuracy"
     early_stopping_metric: "loss"  # when a new high score on this metric is achieved, a checkpoint is written, when "eval_metric" (default) is maximized, when "loss" or "ppl" is minimized
@@ -45,6 +45,7 @@ training: # specify training details here
     use_cuda: False # use CUDA for acceleration on GPU, required. Set to False when working on CPU.
     max_output_length: 31  # maximum output length for decoding, default: None. If set to None, allow sentences of max 1.5*src length
     print_valid_sents: 3  # print this many validation sentences during each validation run, default: 3
+    keep_last_ckpts: 3  # keep this many of the latest checkpoints, if -1: all of them, default: 5
 
 model:  # specify your model architecture here
     tied_embeddings: False  # tie src and trg embeddings, only applicable if vocabularies are the same, default: False
@@ -65,11 +66,11 @@ model:  # specify your model architecture here
             embedding_dim: 16
             scale: False
             freeze: False  # if True, embeddings are not updated during training
-        hidden_size: 31
+        hidden_size: 30
         dropout: 0.2
         hidden_dropout: 0.2 # apply dropout to the attention vector, default: 0.0
         num_layers: 2
         input_feeding: True # combine hidden state and attention vector before feeding to rnn, default: True
-        init_hidden: "bridge" # initialized the decoder hidden state: use linear projection of last encoder state ("bridge") or simply the last state ("last") or zeros ("zero"), default: "bridge"
+        init_hidden: "last" # initialized the decoder hidden state: use linear projection of last encoder state ("bridge") or simply the last state ("last") or zeros ("zero"), default: "bridge"
         attention: "bahdanau" # attention mechanism, choices: "bahdanau" (MLP attention), "luong" (bilinear attention), default: "bahdanau"
         freeze: False  # if True, decoder parameters are not updated during training (does not include embedding parameters, but attention)

--- a/configs/iwslt_deen_bahdanau.yaml
+++ b/configs/iwslt_deen_bahdanau.yaml
@@ -58,5 +58,5 @@ model:
         hidden_dropout: 0.2
         num_layers: 1
         input_feeding: True
-        init_hidden: "zero"
+        init_hidden: "last"
         attention: "luong"

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -5,8 +5,8 @@ Collection of helper functions
 import copy
 import glob
 import os
-import shutil
 import os.path
+import shutil
 import random
 import logging
 from logging import Logger

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -12,6 +12,7 @@ from logging import Logger
 from typing import Callable, Optional, List
 import numpy as np
 import yaml
+import shutil
 
 import torch
 from torch import nn, Tensor
@@ -34,8 +35,9 @@ def make_model_dir(model_dir: str, overwrite=False) -> str:
         if not overwrite:
             raise FileExistsError(
                 "Model directory exists and overwriting is disabled.")
-    else:
-        os.makedirs(model_dir)
+        # delete previous directory to start with empty dir again
+        shutil.rmtree(model_dir)
+    os.makedirs(model_dir)
     return model_dir
 
 

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -5,6 +5,7 @@ Collection of helper functions
 import copy
 import glob
 import os
+import shutil
 import os.path
 import random
 import logging
@@ -12,7 +13,6 @@ from logging import Logger
 from typing import Callable, Optional, List
 import numpy as np
 import yaml
-import shutil
 
 import torch
 from torch import nn, Tensor

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -152,7 +152,12 @@ class TrainManager:
         torch.save(state, model_path)
         if self.ckpt_queue.full():
             to_delete = self.ckpt_queue.get()  # delete oldest ckpt
-            os.remove(to_delete)
+            try:
+                os.remove(to_delete)
+            except FileNotFoundError:
+                self.logger.warning("Wanted to delete old checkpoint %s but "
+                                    "file does not exist.", to_delete)
+
         self.ckpt_queue.put(model_path)
 
     def init_from_checkpoint(self, path: str) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ torchtext
 pyyaml
 subword-nmt
 pylint
-yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ torchtext
 pyyaml
 subword-nmt
 pylint
+yaml

--- a/test/data/iwslt/dev.de
+++ b/test/data/iwslt/dev.de
@@ -1,5 +1,5 @@
-Ja , guten Tag .
 Ich freue mich , dass ich da bin .
+Ja , guten Tag .
 Ja , also , was soll Biohacking sein ?
 Ich muss dazu erst mal ein bisschen ausholen , und zwar beschäftigt sich Biohacking eben mit der modernen Molekularbiologie .
 Ich studiere Molekularbiologie und beschäftige mich eben jetzt seit ein paar Jahren mit dem Biohacking , und das habe ich angefangen , weil ich einfach genauer wissen wollte und es vor allem auch selbst machen wollte , was ich so im Studium theoretisch gelernt habe .

--- a/test/data/iwslt/dev.en
+++ b/test/data/iwslt/dev.en
@@ -1,5 +1,5 @@
-Yes , hello .
 I’m happy to be here .
+Yes , hello .
 Yes , so , what is biohacking ?
 I’ll have to provide some background information here , biohacking deals with modern molecular biology .
 I study molecular biology and have been doing research into biohacking for a few years now , I started doing this because I simply wanted to have more detailed knowledge and especially wanted to put what I’d learned theoretically into practice .

--- a/test/unit/test_attention.py
+++ b/test/unit/test_attention.py
@@ -1,4 +1,3 @@
-from torch.nn import GRU, LSTM
 import torch
 
 from joeynmt.attention import BahdanauAttention, LuongAttention
@@ -8,9 +7,6 @@ from .test_helpers import TensorTestCase
 class TestBahdanauAttention(TensorTestCase):
 
     def setUp(self):
-        self.addTypeEqualityFunc(torch.Tensor,
-                                 lambda x, y, msg: self.failureException(
-                                     msg) if not torch.equal(x, y) else True)
         self.key_size = 3
         self.query_size = 5
         self.hidden_size = 7

--- a/test/unit/test_batch.py
+++ b/test/unit/test_batch.py
@@ -1,0 +1,136 @@
+import torch
+import random
+
+from torchtext.data.batch import Batch as TorchTBatch
+
+from joeynmt.batch import Batch
+from joeynmt.data import load_data, make_data_iter
+from joeynmt.constants import PAD_TOKEN
+from .test_helpers import TensorTestCase
+
+
+class TestData(TensorTestCase):
+
+    def setUp(self):
+        self.train_path = "test/data/iwslt/train"
+        self.dev_path = "test/data/iwslt/dev"
+        self.test_path = "test/data/iwslt/test"
+        self.levels = ["char", "word"]  # bpe is equivalently processed to word
+        self.max_sent_length = 20
+
+        # minimal data config
+        self.data_cfg = {"src": "de", "trg": "en", "train": self.train_path,
+                         "dev": self.dev_path, "level": "char",
+                         "lowercase": True,
+                         "max_sent_length": self.max_sent_length}
+
+        # load the data
+        self.train_data, self.dev_data, self.test_data, src_vocab, trg_vocab = \
+            load_data(self.data_cfg)
+        self.pad_index = trg_vocab.stoi[PAD_TOKEN]
+        # random seeds
+        seed = 42
+        torch.manual_seed(seed)
+        random.seed(42)
+
+    def testBatchTrainIterator(self):
+
+        batch_size = 4
+        self.assertEqual(len(self.train_data), 27)
+
+        # make data iterator
+        train_iter = make_data_iter(self.train_data, train=True, shuffle=True,
+                                    batch_size=batch_size)
+        self.assertEqual(train_iter.batch_size, batch_size)
+        self.assertTrue(train_iter.shuffle)
+        self.assertTrue(train_iter.train)
+        self.assertEqual(train_iter.epoch, 0)
+        self.assertEqual(train_iter.iterations, 0)
+
+        expected_src0 = torch.Tensor(
+            [[21, 10, 4, 16, 4, 5, 21, 4, 12, 33, 6, 14, 4, 12, 23, 6, 18, 4,
+              6, 9, 3],
+             [20, 28, 4, 10, 28, 4, 6, 5, 14, 8, 6, 15, 4, 5, 7, 17, 11, 27,
+              6, 9, 3],
+             [24, 8, 7, 5, 24, 10, 12, 14, 5, 18, 4, 7, 17, 11, 4, 11, 4, 6,
+              25, 3, 1]]).long()
+        expected_src0_len = torch.Tensor([21, 21, 20]).long()
+        expected_trg0 = torch.Tensor(
+            [[6,  4, 27,  5,  8,  4,  5, 31,  4, 26,  7,  6, 10, 20, 11,
+               9,  3],
+             [8,  7,  6, 10, 17,  4, 13,  5, 15,  9,  3,  1,  1,  1,  1,
+              1,  1],
+             [12,  5,  4, 25,  7,  6,  8,  4,  7,  6, 18, 18, 11, 10, 12,
+              23,  3]]).long()
+        expected_trg0_len = torch.Tensor([18, 12, 18]).long()
+
+        total_samples = 0
+        for b in iter(train_iter):
+            b = Batch(torch_batch=b, pad_index=self.pad_index)
+            if total_samples == 0:
+                self.assertTensorEqual(b.src, expected_src0)
+                self.assertTensorEqual(b.src_lengths, expected_src0_len)
+                self.assertTensorEqual(b.trg, expected_trg0)
+                self.assertTensorEqual(b.trg_lengths, expected_trg0_len)
+            total_samples += b.nseqs
+            self.assertLessEqual(b.nseqs, batch_size)
+        self.assertEqual(total_samples, len(self.train_data))
+
+    def testBatchDevIterator(self):
+
+        batch_size = 3
+        self.assertEqual(len(self.dev_data), 20)
+
+        # make data iterator
+        dev_iter = make_data_iter(self.dev_data, train=False, shuffle=False,
+                                  batch_size=batch_size)
+        self.assertEqual(dev_iter.batch_size, batch_size)
+        self.assertFalse(dev_iter.shuffle)
+        self.assertFalse(dev_iter.train)
+        self.assertEqual(dev_iter.epoch, 0)
+        self.assertEqual(dev_iter.iterations, 0)
+
+        expected_src0 = torch.Tensor(
+            [[29, 8, 5, 22, 5, 8, 16, 7, 19, 5, 22, 5, 24, 8, 7, 5, 7, 19,
+              16, 16, 5, 31, 10, 19, 11, 8, 17, 15, 10, 6, 18, 5, 7, 4, 10, 6,
+              5, 25, 3],
+             [10, 17, 11, 5, 28, 12, 4, 23, 4, 5, 0, 10, 17, 11, 5, 22, 5, 14,
+              8, 7, 7, 5, 10, 17, 11, 5, 14, 8, 5, 31, 10, 6, 5, 9, 3, 1,
+              1, 1, 1],
+             [29, 8, 5, 22, 5, 18, 23, 13, 4, 6, 5, 13, 8, 18, 5, 9, 3, 1,
+              1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+              1, 1, 1]]).long()
+        expected_src0_len = torch.Tensor([39, 35, 17]).long()
+        expected_trg0 = torch.Tensor(
+            [[13, 11, 12, 4, 22, 4, 12, 5, 4, 22, 4, 25, 7, 6, 8, 4, 14, 12,
+              4, 24, 14, 5, 7, 6, 26, 17, 14, 10, 20, 4, 23, 3],
+             [14, 0, 28, 4, 7, 6, 18, 18, 13, 4, 8, 5, 4, 24, 11, 4, 7, 11,
+              16, 11, 4, 9, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+             [13, 11, 12, 4, 22, 4, 7, 11, 27, 27, 5, 4, 9, 3, 1, 1, 1, 1,
+              1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]).long()
+        expected_trg0_len = torch.Tensor([33, 24, 15]).long()
+
+        total_samples = 0
+        for b in iter(dev_iter):
+            self.assertEqual(type(b), TorchTBatch)
+            b = Batch(b, pad_index=self.pad_index)
+
+            # test the sorting by src length
+            self.assertEqual(type(b), Batch)
+            before_sort = b.src_lengths
+            b.sort_by_src_lengths()
+            after_sort = b.src_lengths
+            self.assertTensorEqual(torch.sort(before_sort, descending=True)[0],
+                                   after_sort)
+            self.assertEqual(type(b), Batch)
+
+            if total_samples == 0:
+                self.assertTensorEqual(b.src, expected_src0)
+                self.assertTensorEqual(b.src_lengths, expected_src0_len)
+                self.assertTensorEqual(b.trg, expected_trg0)
+                self.assertTensorEqual(b.trg_lengths, expected_trg0_len)
+            total_samples += b.nseqs
+            self.assertLessEqual(b.nseqs, batch_size)
+        self.assertEqual(total_samples, len(self.dev_data))
+
+

--- a/test/unit/test_decoder.py
+++ b/test/unit/test_decoder.py
@@ -9,9 +9,6 @@ from .test_helpers import TensorTestCase
 class TestRecurrentDecoder(TensorTestCase):
 
     def setUp(self):
-        self.addTypeEqualityFunc(torch.Tensor,
-                                 lambda x, y, msg: self.failureException(
-                                     msg) if not torch.equal(x, y) else True)
         self.emb_size = 10
         self.num_layers = 3
         self.hidden_size = 6

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -4,12 +4,10 @@ import torch
 from joeynmt.encoders import RecurrentEncoder
 from .test_helpers import TensorTestCase
 
+
 class TestRecurrentEncoder(TensorTestCase):
 
     def setUp(self):
-        self.addTypeEqualityFunc(torch.Tensor,
-                                 lambda x, y, msg: self.failureException(
-                                     msg) if not torch.equal(x, y) else True)
         self.emb_size = 10
         self.num_layers = 3
         self.hidden_size = 7


### PR DESCRIPTION
Unittests
- added unit tests for batch creation and data iterators
- cleaned up the old ones

README
- cleaner tables: config in text

Checkpoints
- added configuration attribute `keep_last_ckpts` -> only this many checkpoints are saved
- if set to -1, all are checkpoints are kept
- otherwise deletes old ones, "old" in terms of time stamp: the later they are written, the better they must be (since they only get written when a new best validation result is achieved)
- default: keep the last 5

Overwriting
- when overwriting is activated, the complete content of the model directory is deleted
- this makes sure no old checkpoints or validation scripts are interfering
- however, this means that you should basically never ever use `overwrite: True`

Bridge
- when `brigde: "last" ` the model previously expected the last encoder hidden state to be exactly the same size as the decoder state
- added the special case for using bi-directional RNNs: the last encoder hidden state is twice the size of the decoder state, so only the first half of the last encoder hidden state (the forward hidden state) is used for initializing the decoder state
- this is in fact the configuration that was used in W&R