### PR TITLE
Use yaml.safe_load instead of deprecated yaml.load

### DIFF
--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -163,7 +163,7 @@ def load_config(path="configs/default.yaml") -> dict:
     :return: configuration dictionary
     """
     with open(path, 'r') as ymlfile:
-        cfg = yaml.load(ymlfile)
+        cfg = yaml.safe_load(ymlfile)
     return cfg
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib
 sacrebleu>=1.2.10
 seaborn
 torchtext
-pyyaml
+pyyaml>=5.1
 subword-nmt
 pylint
 tensorboardX


### PR DESCRIPTION
Invoking yaml.load without a *Loader*-Argument is deprecated as
of pyyaml 5.1 due to possible RCE issues. See msg.pyyaml.org/load
for deatails.