### PR TITLE
Adjust installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,10 @@ Joey NMT is built on [PyTorch](https://pytorch.org/) and [torchtext](https://git
 
 1. Clone this repository:
 `git clone https://github.com/joeynmt/joeynmt.git`
-2. Install the requirements:
+2. Install joeynmt and it's requirements:
 `cd joeynmt`
-`pip3 install -r requirements.txt` (you might want to add `--user` for a local installation).
-3. Install joeynmt:
-`pip3 install .` (you can add `--user` the same way you can when installing requirenments).
-4. Run the unit tests:
+`pip3 install .` (you might want to add `--user` for a local installation).
+3. Run the unit tests:
 `python3 -m unittest`
 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Joey NMT is built on [PyTorch](https://pytorch.org/) and [torchtext](https://git
 `cd joeynmt`
 `pip3 install -r requirements.txt` (you might want to add `--user` for a local installation).
 3. Install joeynmt:
-`python3 setup.py install`
+`pip3 install .` (you can add `--user` the same way you can when installing requirenments).
 4. Run the unit tests:
 `python3 -m unittest`
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -28,24 +28,14 @@ Then clone JoeyNMT from GitHub and switch to its root directory:
    (jnmt)$ cd joeynmt
 
 
-Requirements
-------------
+Installing JoeyNMT
+------------------
 
-Install the python requirements with pip:
-
-.. code-block:: bash
-
-   (jnmt)$ pip install --upgrade -r requirements.txt
-
-
-JoeyNMT
--------
-
-Install JoeyNMT:
+Install JoeyNMT and it's requirements:
 
 .. code-block:: bash
 
-   (jnmt)$ python3 setup.py install
+   (jnmt)$ pip3 install .
 
 Run the unit tests to make sure your installation is working:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -7,7 +7,7 @@ Installation
 Basics
 ------
 
-First install `Python <https://www.python.org/>`_ >= 3.6, `PyTorch <https://pytorch.org/>`_ >=v.0.4.1 and `git <https://git-scm.com/>`_.
+First install `Python <https://www.python.org/>`_ >= 3.5, `PyTorch <https://pytorch.org/>`_ >=v.0.4.1 and `git <https://git-scm.com/>`_.
 
 Create and activate a `virtual environment <https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments>`_ to install the package into:
 


### PR DESCRIPTION
If you install joeynmt via `pip3 install .` rather than `python3 setup.py install` there are two main benefits:

- Easy local installation using the `--user` flag
- Requirements are handled automatically by pip, removing an extra step from the process.