### PR TITLE
add src trg softmax tying and tying tests

### DIFF
--- a/configs/reverse.yaml
+++ b/configs/reverse.yaml
@@ -34,7 +34,7 @@ training:
     patience: 5
     decrease_factor: 0.5
     early_stopping_metric: "eval_metric"
-    epochs: 1
+    epochs: 6
     validation_freq: 1000
     logging_freq: 100
     eval_metric: "bleu"

--- a/configs/reverse.yaml
+++ b/configs/reverse.yaml
@@ -41,7 +41,7 @@ training:
     model_dir: "reverse_model"
     overwrite: True
     shuffle: True
-    use_cuda: True
+    use_cuda: False
     max_output_length: 30
     print_valid_sents: [0, 3, 6]
     keep_last_ckpts: 2

--- a/configs/reverse.yaml
+++ b/configs/reverse.yaml
@@ -34,14 +34,14 @@ training:
     patience: 5
     decrease_factor: 0.5
     early_stopping_metric: "eval_metric"
-    epochs: 6
+    epochs: 1
     validation_freq: 1000
     logging_freq: 100
     eval_metric: "bleu"
     model_dir: "reverse_model"
     overwrite: True
     shuffle: True
-    use_cuda: False
+    use_cuda: True
     max_output_length: 30
     print_valid_sents: [0, 3, 6]
     keep_last_ckpts: 2

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -60,6 +60,7 @@ model:                              # specify your model architecture here
     init_rnn_orthogonal: False      # use orthogonal initialization for recurrent weights (default: False)
     lstm_forget_gate: 0.            # initialize LSTM forget gate with this value (default: 0.)
     tied_embeddings: False          # tie src and trg embeddings, only applicable if vocabularies are the same, default: False
+    tied_softmax: False             # tie trg embeddings and softmax (for Transformer; can be used together with tied_embeddings), default: False
     encoder:
         type: "recurrent"           # encoder type: "recurrent" for LSTM or GRU, or "transformer" for a Transformer
         rnn_type: "gru"             # type of recurrent unit to use, either "gru" or "lstm", default: "lstm"

--- a/configs/transformer_reverse.yaml
+++ b/configs/transformer_reverse.yaml
@@ -40,7 +40,7 @@ training:
     model_dir: "transformer_reverse"
     overwrite: False
     shuffle: True
-    use_cuda: True
+    use_cuda: False
     max_output_length: 30
     print_valid_sents: [0, 3, 6, 9]
     keep_last_ckpts: 2

--- a/configs/transformer_reverse.yaml
+++ b/configs/transformer_reverse.yaml
@@ -29,6 +29,7 @@ training:
     learning_rate_min: 0.00000001
     learning_rate_factor: 1   # factor for Noam scheduler (default: 1)
     learning_rate_warmup: 5000  # warmup steps for Noam scheduler
+    label_smoothing: 0.1
     weight_decay: 0.0
     batch_size: 250
     batch_type: "token"
@@ -43,13 +44,15 @@ training:
     max_output_length: 30
     print_valid_sents: [0, 3, 6, 9]
     keep_last_ckpts: 2
-    label_smoothing: 0.01
+
 
 model:
     initializer: "xavier"
     embed_initializer: "normal"
     embed_init_weight: 0.05
     bias_initializer: "zeros"
+    tied_embeddings: True          # tie src and trg embeddings, only applicable if vocabularies are the same, default: False
+    tied_softmax: True
     encoder:
         type: "transformer"
         num_layers: 2

--- a/configs/transformer_small.yaml
+++ b/configs/transformer_small.yaml
@@ -56,6 +56,7 @@ model:                              # specify your model architecture here
     embed_initializer: "normal"     # initializer for embeddings (xavier, zeros, normal, uniform)
     embed_init_weight: 0.05         # weight to initialize; for uniform, will use [-weight, weight]
     tied_embeddings: False          # tie src and trg embeddings, only applicable if vocabularies are the same, default: False
+    tied_softmax: True
     encoder:
         type: "transformer"          # encoder type: "recurrent" for LSTM or GRU, or "transformer" for a Transformer
         num_layers: 3               # number of layers

--- a/joeynmt/decoders.py
+++ b/joeynmt/decoders.py
@@ -42,7 +42,7 @@ class RecurrentDecoder(Decoder):
                  hidden_size: int = 0,
                  encoder: Encoder = None,
                  attention: str = "bahdanau",
-                 num_layers: int = 0,
+                 num_layers: int = 1,
                  vocab_size: int = 0,
                  dropout: float = 0.,
                  hidden_dropout: float = 0.,

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -263,7 +263,9 @@ def build_model(cfg: dict = None,
             model.decoder.output_layer.weight = trg_embed.lut.weight
         else:
             raise ConfigurationError(
-                "Trg embedding size and hidden_size must be equal for tying.")
+                "For tied_softmax, the decoder embedding_dim and decoder "
+                "hidden_size must be the same."
+                "The decoder must be a Transformer.")
 
     # custom initialization of model parameters
     initialize_model(model, cfg, src_padding_idx, trg_padding_idx)

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -257,7 +257,8 @@ def build_model(cfg: dict = None,
 
     # tie softmax layer with trg embeddings
     if cfg.get("tied_softmax", False):
-        if trg_embed.lut.weight.shape[1] == cfg["decoder"]["hidden_size"]:
+        if trg_embed.lut.weight.shape == \
+                model.decoder.output_layer.weight.shape:
             # (also) share trg embeddings and softmax layer:
             model.decoder.output_layer.weight = trg_embed.lut.weight
         else:

--- a/test/unit/test_weight_tying.py
+++ b/test/unit/test_weight_tying.py
@@ -86,3 +86,13 @@ class TestWeightTying(TensorTestCase):
                                model.trg_embed.lut.weight)
         self.assertEqual(model.src_embed.lut.weight.shape,
                          model.trg_embed.lut.weight.shape)
+
+        model.decoder.output_layer.weight.data.fill_(3.)
+        self.assertEqual(model.decoder.output_layer.weight.sum().item(),
+                         6528)
+        self.assertEqual(model.decoder.output_layer.weight.sum().item(),
+                         model.trg_embed.lut.weight.sum().item())
+        self.assertEqual(model.decoder.output_layer.weight.sum().item(),
+                         model.src_embed.lut.weight.sum().item())
+        self.assertEqual(model.src_embed.lut.weight.sum().item(),
+                         model.trg_embed.lut.weight.sum().item())

--- a/test/unit/test_weight_tying.py
+++ b/test/unit/test_weight_tying.py
@@ -9,7 +9,7 @@ from joeynmt.vocabulary import Vocabulary
 import copy
 
 
-class TestRecurrentEncoder(TensorTestCase):
+class TestWeightTying(TensorTestCase):
 
     def setUp(self):
         self.seed = 42

--- a/test/unit/test_weight_tying.py
+++ b/test/unit/test_weight_tying.py
@@ -1,0 +1,88 @@
+from torch.nn import GRU, LSTM
+import torch
+import numpy as np
+
+from joeynmt.encoders import RecurrentEncoder
+from .test_helpers import TensorTestCase
+from joeynmt.model import build_model
+from joeynmt.vocabulary import Vocabulary
+import copy
+
+
+class TestRecurrentEncoder(TensorTestCase):
+
+    def setUp(self):
+        self.seed = 42
+        vocab_size = 30
+        tokens = ["tok{:02d}".format(i) for i in range(vocab_size)]
+        self.vocab = Vocabulary(tokens=tokens)
+
+        self.cfg = {
+            "model": {
+                "tied_embeddings": False,
+                "tied_softmax": False,
+                "encoder": {
+                    "type": "recurrent",
+                    "hidden_size": 64,
+                    "embeddings": {"embedding_dim": 32},
+                    "num_layers": 1,
+                },
+                "decoder": {
+                    "type": "recurrent",
+                    "hidden_size": 64,
+                    "embeddings": {"embedding_dim": 32},
+                    "num_layers": 1,
+                },
+            }
+        }
+
+    def test_tied_src_trg_embeddings(self):
+
+        torch.manual_seed(self.seed)
+        cfg = copy.deepcopy(self.cfg)
+        cfg["model"]["tied_embeddings"] = True
+        cfg["model"]["tied_softmax"] = False
+
+        src_vocab = trg_vocab = self.vocab
+
+        model = build_model(cfg["model"],
+                            src_vocab=src_vocab, trg_vocab=trg_vocab)
+
+        self.assertEqual(src_vocab.itos, trg_vocab.itos)
+        self.assertEqual(model.src_embed, model.trg_embed)
+        self.assertTensorEqual(model.src_embed.lut.weight,
+                               model.trg_embed.lut.weight)
+        self.assertEqual(model.src_embed.lut.weight.shape,
+                         model.trg_embed.lut.weight.shape)
+
+    def test_tied_softmax(self):
+
+        torch.manual_seed(self.seed)
+
+        cfg = copy.deepcopy(self.cfg)
+        cfg["model"]["decoder"]["type"] = "transformer"
+        cfg["model"]["tied_embeddings"] = False
+        cfg["model"]["tied_softmax"] = True
+        cfg["model"]["decoder"]["embeddings"]["embedding_dim"] = 64
+
+        src_vocab = trg_vocab = self.vocab
+
+        model = build_model(cfg["model"],
+                            src_vocab=src_vocab, trg_vocab=trg_vocab)
+
+        self.assertEqual(model.trg_embed.lut.weight.shape,
+                         model.decoder.output_layer.weight.shape)
+
+        self.assertTensorEqual(model.trg_embed.lut.weight,
+                               model.decoder.output_layer.weight)
+
+        # test source embedding, target embedding, and softmax tying
+        cfg["model"]["tied_embeddings"] = True
+        cfg["model"]["encoder"]["embeddings"]["embedding_dim"] = 64
+        model = build_model(cfg["model"],
+                            src_vocab=src_vocab, trg_vocab=trg_vocab)
+
+        self.assertTensorEqual(model.src_embed.lut.weight,
+                               model.trg_embed.lut.weight)
+        self.assertEqual(model.src_embed.lut.weight.shape,
+                         model.trg_embed.lut.weight.shape)


### PR DESCRIPTION
This adds test for weight tying and adds weight tying between target embeddings and softmax.
If the source and target embeddings are also tied, there is a three-way tying.

Note that the decoder default number of layers was changed to 1 to match the encoder.