### PR TITLE
Bugfix for batch multiplier initialization in training.py

### DIFF
--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -239,7 +239,7 @@ class TrainManager:
             start = time.time()
             total_valid_duration = 0
             processed_tokens = self.total_tokens
-            count = 0
+            count = self.batch_multiplier - 1
             epoch_loss = 0
 
             for batch in iter(train_iter):


### PR DESCRIPTION
The batch multiplier is implemented via a `count`, which is reset to
`self.batch_multiplier-1` every time an update occurs. It is initialized
with `0`, however, rather than `self.batch_multiplier-1`. This commit
fixes the issue and initializes `count` with `self.batch_multiplier-1`.