### PR TITLE
Resetting of high scores, scheduler and optimizer for fine-tuning/domain adaptation

### DIFF
--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -23,7 +23,10 @@ testing:                            # specify which inference algorithm to use f
     alpha: 1.0                      # length penalty for beam search
 
 training:                           # specify training details here
-    #load_model: "my_model/50.ckpt" # if given, load a pre-trained model from this checkpoint
+    #load_model: "models/small_model/60.ckpt" # if given, load a pre-trained model from this checkpoint
+    reset_best_ckpt: False          # if True, reset the tracking of the best checkpoint and scores. Use for domain adaptation or fine-tuning with new metrics or dev data.
+    reset_scheduler: False          # if True, overwrite scheduler in loaded checkpoint with parameters specified in this config. Use for domain adaptation or fine-tuning.
+    reset_optimizer: False          # if True, overwrite optimizer in loaded checkpoint with parameters specified in this config. Use for domain adaptation or fine-tuning.
     random_seed: 42                 # set this seed to make training deterministic
     optimizer: "adam"               # choices: "sgd", "adam", "adadelta", "adagrad", "rmsprop", default is SGD
     adam_betas: [0.9, 0.999]        # beta parameters for Adam. These are the defaults. Typically these are different for Transformer models.
@@ -46,7 +49,7 @@ training:                           # specify training details here
     validation_freq: 10             # validate after this many updates (number of mini-batches), default: 1000
     logging_freq: 10                # log the training progress after this many updates, default: 100
     eval_metric: "bleu"             # validation metric, default: "bleu", other options: "chrf", "token_accuracy", "sequence_accuracy"
-    early_stopping_metric: "loss"   # when a new high score on this metric is achieved, a checkpoint is written, when "eval_metric" (default) is maximized, when "loss" or "ppl" is minimized
+    early_stopping_metric: "eval_metric"   # when a new high score on this metric is achieved, a checkpoint is written, when "eval_metric" (default) is maximized, when "loss" or "ppl" is minimized
     model_dir: "models/small_model" # directory where models and validation results are stored, required
     overwrite: True                 # overwrite existing model directory, default: False. Do not set to True unless for debugging!
     shuffle: True                   # shuffle the training data, default: True

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -49,7 +49,7 @@ training:                           # specify training details here
     validation_freq: 10             # validate after this many updates (number of mini-batches), default: 1000
     logging_freq: 10                # log the training progress after this many updates, default: 100
     eval_metric: "bleu"             # validation metric, default: "bleu", other options: "chrf", "token_accuracy", "sequence_accuracy"
-    early_stopping_metric: "eval_metric"   # when a new high score on this metric is achieved, a checkpoint is written, when "eval_metric" (default) is maximized, when "loss" or "ppl" is minimized
+    early_stopping_metric: "loss"   # when a new high score on this metric is achieved, a checkpoint is written, when "eval_metric" (default) is maximized, when "loss" or "ppl" is minimized
     model_dir: "models/small_model" # directory where models and validation results are stored, required
     overwrite: True                 # overwrite existing model directory, default: False. Do not set to True unless for debugging!
     shuffle: True                   # shuffle the training data, default: True

--- a/configs/transformer_small.yaml
+++ b/configs/transformer_small.yaml
@@ -21,7 +21,10 @@ testing:                            # specify which inference algorithm to use f
     alpha: 1.0                      # length penalty for beam search
 
 training:                           # specify training details here
-    #load_model: "my_model/50.ckpt" # if given, load a pre-trained model from this checkpoint
+    #load_model: "models/transformer/60.ckpt" # if given, load a pre-trained model from this checkpoint
+    reset_best_ckpt: False          # if True, reset the tracking of the best checkpoint and scores. Use for domain adaptation or fine-tuning with new metrics or dev data.
+    reset_scheduler: False          # if True, overwrite scheduler in loaded checkpoint with parameters specified in this config. Use for domain adaptation or fine-tuning.
+    reset_optimizer: False          # if True, overwrite optimizer in loaded checkpoint with parameters specified in this config. Use for domain adaptation or fine-tuning.
     random_seed: 42                 # set this seed to make training deterministic
     optimizer: "adam"               # choices: "sgd", "adam", "adadelta", "adagrad", "rmsprop", default is SGD
     adam_betas: [0.9, 0.98]         # beta parameters for Adam. These are the defaults. Typically these are different for Transformer models.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -38,12 +38,15 @@ Training
    Depends on the size of your data. For most use-cases you want to validate at least once per epoch.
    Say you have 100k training examples and train with mini-batches of size 20, then you should set ``validation_freq`` to 5000 (100k/20) to validate once per epoch.
 
-- **How can I perform domain adaptation?**
+- **How can I perform domain adaptation or fine-tuning?**
+   Both approaches are similar, so we call the fine-tuning data *in-domain* data in the following.
    1. First train your model on one dataset (the *out-of-domain* data).
    2. Modify the original configuration file (or better a copy of it) in the data section to point to the new *in-domain* data.
     Specify which vocabularies to use: ``src_vocab: out-of-domain-model/src_vocab.txt`` and likewise for ``trg_vocab``.
     You have to specify this, otherwise JoeyNMT will try to build a new vocabulary from the new in-domain data, which the out-of-domain model wasn't built with.
     In the training section, specify which checkpoint of the out-of-domain model you want to start adapting: ``load_model: out-of-domain-model/best.ckpt``.
+    If you set ``reset_best_ckpt'': True'', previously stored high scores under your metric will be ignored, and if you set ``reset_scheduler'' and ``reset_optimizer'' you can also overwrite the stored scheduler and optimizer with the new ones in your configuration.
+    Use this if the scores on your new dev set are lower than on the old dev set, or if you use a different metric or schedule for fine-tuning.
    3. Train the in-domain model.
 
 - **What if training is interrupted and I need to resume it?**


### PR DESCRIPTION
In the case of fine-tuning or domain adaptation, one might want to overwrite the existing scheduler or optimizer or the previously tracked high score. 
This is specifically relevant when fine-tuning with a different metric or a data where the validation score is in a different range than the loaded model (e.g. pre-training on BLEU and fine-tuning on PPL would result in never storing a new checkpoint). When the data is much smaller than the previous training data, one might want to reduce the patience.

We can also think about modeling this as "load_x_from_ckpt" rather than "reset_x", but for now, it seems that in the default case we want to load everything.