### PR TITLE
Random subset

### DIFF
--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -8,6 +8,7 @@ data: # specify your data here
     train: "test/data/toy/train"    # training data
     dev: "test/data/toy/dev"        # development data for validation
     test: "test/data/toy/test"      # test data for testing final model; optional
+    random_train_subset: -1         # select this many training examples randomly for training and discard the rest, -1: all
     level: "word"                   # segmentation level: either "word", "bpe" or "char"
     lowercase: True                 # lowercase the data, also for validation
     max_sent_length: 30             # filter out longer sentences from training (src+trg)

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -18,6 +18,9 @@ Training
 - **How can I stop training?**
    Simply press Control+C.
 
+- **My training data is huge and I actually don't want to train on it all. What can I do?**
+    You could use the ``random_train_subset`` parameter in the data section of the configuration to load only a random subset of the training data. If you change the random seed, this selection changes too. So you could train on multiple random subsets and then ensemble the models with ``scripts/average_checkpoints.py``.
+
 - **How can I see how well my model is doing?**
    1. *Training log*: Validation results and training loss (after each epoch and batch) are reported in the training log file ``train.log`` in your model directory.
    2. *Validation reports*: ``validations.txt`` contains the validation results, learning rates and indicators when a checkpoint was saved. You can easily plot the validation results with `this script <https://github.com/joeynmt/joeynmt/blob/master/scripts/plot_validations.py>`_, e.g.

--- a/joeynmt/data.py
+++ b/joeynmt/data.py
@@ -27,6 +27,9 @@ def load_data(data_cfg: dict) -> (Dataset, Dataset, Optional[Dataset],
     The training data is filtered to include sentences up to `max_sent_length`
     on source and target side.
 
+    If you set ``random_train_subset``, a random selection of this size is used
+    from the training set instead of the full training set.
+
     :param data_cfg: configuration dictionary for data
         ("data" part of configuation file)
     :return:

--- a/joeynmt/data.py
+++ b/joeynmt/data.py
@@ -3,6 +3,7 @@
 Data module
 """
 import sys
+import random
 import os
 import os.path
 from typing import Optional
@@ -82,6 +83,16 @@ def load_data(data_cfg: dict) -> (Dataset, Dataset, Optional[Dataset],
     trg_vocab = build_vocab(field="trg", min_freq=trg_min_freq,
                             max_size=trg_max_size,
                             dataset=train_data, vocab_file=trg_vocab_file)
+
+    random_train_subset = data_cfg.get("random_train_subset", -1)
+    if random_train_subset > -1:
+        # select this many training examples randomly and discard the rest
+        keep_ratio = random_train_subset / len(train_data)
+        keep, discard = train_data.split(
+            split_ratio=[keep_ratio, 1 - keep_ratio],
+            random_state=random.getstate())
+        train_data = keep
+
     dev_data = TranslationDataset(path=dev_path,
                                   exts=("." + src_lang, "." + trg_lang),
                                   fields=(src_field, trg_field))

--- a/joeynmt/data.py
+++ b/joeynmt/data.py
@@ -91,7 +91,7 @@ def load_data(data_cfg: dict) -> (Dataset, Dataset, Optional[Dataset],
     if random_train_subset > -1:
         # select this many training examples randomly and discard the rest
         keep_ratio = random_train_subset / len(train_data)
-        keep, discard = train_data.split(
+        keep, _ = train_data.split(
             split_ratio=[keep_ratio, 1 - keep_ratio],
             random_state=random.getstate())
         train_data = keep

--- a/test/unit/test_data.py
+++ b/test/unit/test_data.py
@@ -16,14 +16,13 @@ class TestData(unittest.TestCase):
 
         # minimal data config
         self.data_cfg = {"src": "de", "trg": "en", "train": self.train_path,
-                         "dev": self.dev_path,
+                         "dev": self.dev_path, "level": "word",
+                         "lowercase": False,
                          "max_sent_length": self.max_sent_length}
 
     def testIteratorBatchType(self):
 
         current_cfg = self.data_cfg.copy()
-        current_cfg["level"] = "word"
-        current_cfg["lowercase"] = False
 
         # load toy data
         train_data, dev_data, test_data, src_vocab, trg_vocab = \
@@ -142,3 +141,18 @@ class TestData(unittest.TestCase):
                             comparison_trg = expected_trgs[level].split()
                     self.assertEqual(train_data.examples[0].src, comparison_src)
                     self.assertEqual(train_data.examples[0].trg, comparison_trg)
+
+    def testRandomSubset(self):
+        # only a random subset should be selected for training
+        current_cfg = self.data_cfg.copy()
+        current_cfg["random_train_subset"] = -1
+
+        # load the data
+        train_data, dev_data, test_data, src_vocab, trg_vocab = \
+            load_data(current_cfg)
+        assert len(train_data) == 382
+
+        current_cfg["random_train_subset"] = 10
+        train_data, dev_data, test_data, src_vocab, trg_vocab = \
+            load_data(current_cfg)
+        assert len(train_data) == 10


### PR DESCRIPTION
If training data is very large, one might want to train on a randomly selection of training instances. The new `random_train_subset` parameter allows to reduce the size of the training data. The random selection is dependent on the random seed.