### PR TITLE
bugfix: token_accuracy for level=char

### DIFF
--- a/joeynmt/metrics.py
+++ b/joeynmt/metrics.py
@@ -39,14 +39,14 @@ def token_accuracy(hypotheses, references, level="word"):
     :param level: segmentation level, either "word", "bpe", or "char"
     :return:
     """
-    def split_by_space(input):
+    def split_by_space(string):
         """
         Helper method to split the input based on spaces.
-        Follows the same as list(input)
-        :param input: string
+        Follows the same structure as list(inp)
+        :param string: string
         :return: list of strings
         """
-        return input.split(" ")
+        return string.split(" ")
 
     correct_tokens = 0
     all_tokens = 0

--- a/joeynmt/metrics.py
+++ b/joeynmt/metrics.py
@@ -39,13 +39,22 @@ def token_accuracy(hypotheses, references, level="word"):
     :param level: segmentation level, either "word", "bpe", or "char"
     :return:
     """
+    def split_by_space(input):
+        """
+        Helper method to split the input based on spaces.
+        Follows the same as list(input)
+        :param input: string
+        :return: list of strings
+        """
+        return input.split(" ")
+
     correct_tokens = 0
     all_tokens = 0
-    split_char = " " if level in ["word", "bpe"] else ""
+    split_func = split_by_space if level in ["word", "bpe"] else list
     assert len(hypotheses) == len(references)
     for hyp, ref in zip(hypotheses, references):
         all_tokens += len(hyp)
-        for h_i, r_i in zip(hyp.split(split_char), ref.split(split_char)):
+        for h_i, r_i in zip(split_func(hyp), split_func(ref)):
             # min(len(h), len(r)) tokens considered
             if h_i == r_i:
                 correct_tokens += 1

--- a/test/unit/test_metric.py
+++ b/test/unit/test_metric.py
@@ -1,0 +1,13 @@
+from test.unit.test_helpers import TensorTestCase
+
+from joeynmt.metrics import token_accuracy
+
+
+class TestMetrics(TensorTestCase):
+
+    def test_token_acc_level_char(self):
+        hyp = ["test"]
+        ref = ["tezt"]
+        level = "char"
+        acc = token_accuracy(hyp, ref, level)
+        self.assertEqual(acc, 75)


### PR DESCRIPTION
Found a small bug in the token_accuracy method.
`ref.split("")`
Will always throw a "ValueError: Empty separator".
Therefor the token_accuracy can only be calculated for segmentation levels "word" and "bpe"

Kind regards