### PR TITLE
eval_metric can be token_ or sequence_accuracy

### DIFF
--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -84,9 +84,9 @@ class TrainManager:
         self.ckpt_queue = queue.Queue(
             maxsize=train_config.get("keep_last_ckpts", 5))
         self.eval_metric = train_config.get("eval_metric", "bleu")
-        if self.eval_metric not in ['bleu', 'chrf']:
+        if self.eval_metric not in ['bleu', 'chrf', 'token_accuracy', 'sequence_accuracy']:
             raise ConfigurationError("Invalid setting for 'eval_metric', "
-                                     "valid options: 'bleu', 'chrf'.")
+                                     "valid options: 'bleu', 'chrf', 'token_accuracy', 'sequence_accuracy'.")
         self.early_stopping_metric = train_config.get("early_stopping_metric",
                                                       "eval_metric")
 

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -84,9 +84,13 @@ class TrainManager:
         self.ckpt_queue = queue.Queue(
             maxsize=train_config.get("keep_last_ckpts", 5))
         self.eval_metric = train_config.get("eval_metric", "bleu")
-        if self.eval_metric not in ['bleu', 'chrf', 'token_accuracy', 'sequence_accuracy']:
+        if self.eval_metric not in ['bleu',
+                                    'chrf',
+                                    'token_accuracy',
+                                    'sequence_accuracy']:
             raise ConfigurationError("Invalid setting for 'eval_metric', "
-                                     "valid options: 'bleu', 'chrf', 'token_accuracy', 'sequence_accuracy'.")
+                                     "valid options: 'bleu', 'chrf', "
+                                     "'token_accuracy', 'sequence_accuracy'.")
         self.early_stopping_metric = train_config.get("early_stopping_metric",
                                                       "eval_metric")
 


### PR DESCRIPTION
Sorry forgot to activate the accuracy options in training.py. 
Tested both accuracy metrics for transfomer_small.yaml and small.yaml.