### PR TITLE
Fixed up setup.py to support external scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
+#!/usr/bin/env python
 from setuptools import setup, find_packages
-#from distutils.core import Extension
 import sys
 import os
-
-#sys.path.append("./joeynmt")
 
 with open("requirements.txt", encoding="utf-8") as req_fp:
   install_requires = req_fp.readlines()


### PR DESCRIPTION
This allowed the joeynmt script can be called from outside of the folder on my system