### PR TITLE
'

### DIFF
--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -298,6 +298,7 @@ class TrainManager:
             total_valid_duration = 0
             start_tokens = self.total_tokens
             self.current_batch_multiplier = self.batch_multiplier
+            self.optimizer.zero_grad()
             count = self.current_batch_multiplier - 1
             epoch_loss = 0
 
@@ -314,11 +315,13 @@ class TrainManager:
 
                 # Set current_batch_mutliplier to fit
                 # number of leftover examples for last batch in epoch
-                if self.batch_multiplier > 1 and i == len(train_iter) - \
-                        math.ceil(leftover_batch_size / self.batch_size):
-                    self.current_batch_multiplier = math.ceil(
-                        leftover_batch_size / self.batch_size)
-                    count = self.current_batch_multiplier - 1
+                # Only works if batch_type == sentence
+                if self.batch_type == "sentence":
+                    if self.batch_multiplier > 1 and i == len(train_iter) - \
+                            math.ceil(leftover_batch_size / self.batch_size):
+                        self.current_batch_multiplier = math.ceil(
+                            leftover_batch_size / self.batch_size)
+                        count = self.current_batch_multiplier - 1
 
                 update = count == 0
                 # print(count, update, self.steps)


### PR DESCRIPTION
…r examples, if batch_type == "sentence".

The optimizer gradients now get set to zero at the start of each epoch to effectively skip the leftover examples of the last epoch that get computed if batch_type == "token"