### PR TITLE
Fix for batch_multiplier, now works properly for batch_type == "token"

### DIFF
--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -298,6 +298,7 @@ class TrainManager:
             total_valid_duration = 0
             start_tokens = self.total_tokens
             self.current_batch_multiplier = self.batch_multiplier
+            self.optimizer.zero_grad()
             count = self.current_batch_multiplier - 1
             epoch_loss = 0
 
@@ -314,11 +315,13 @@ class TrainManager:
 
                 # Set current_batch_mutliplier to fit
                 # number of leftover examples for last batch in epoch
-                if self.batch_multiplier > 1 and i == len(train_iter) - \
-                        math.ceil(leftover_batch_size / self.batch_size):
-                    self.current_batch_multiplier = math.ceil(
-                        leftover_batch_size / self.batch_size)
-                    count = self.current_batch_multiplier - 1
+                # Only works if batch_type == sentence
+                if self.batch_type == "sentence":
+                    if self.batch_multiplier > 1 and i == len(train_iter) - \
+                            math.ceil(leftover_batch_size / self.batch_size):
+                        self.current_batch_multiplier = math.ceil(
+                            leftover_batch_size / self.batch_size)
+                        count = self.current_batch_multiplier - 1
 
                 update = count == 0
                 # print(count, update, self.steps)


### PR DESCRIPTION
Fixes #90 
The current batch multiplier now only gets computed/changed in training 
if batch_type == "sentence". 
To avoid the problem of accumulating the gradients of the leftover examples at the end of an epoch to the gradients computed with the first batch in the next epoch (see d184815),
if batch_type == "token", the optimizer gradients now get set to zero at the start of each epoch. 