### PR TITLE
add flag for keeping/removing BPE splits

### DIFF
--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,6 +1,6 @@
 name: "my_experiment"
 
-# This configuration serves the purpose of documenting and explaining the settings, *NOT* as an example for good hyperparamter settings.
+# This configuration serves the purpose of documenting and explaining the settings, *NOT* as an example for good hyperparameter settings.
 
 data: # specify your data here
     src: "de"                       # src language: expected suffix of train files, e.g. "train.de"
@@ -22,6 +22,7 @@ data: # specify your data here
 testing:                            # specify which inference algorithm to use for testing (for validation it's always greedy decoding)
     beam_size: 5                    # size of the beam for beam search
     alpha: 1.0                      # length penalty for beam search
+    postprocess: True               # remove BPE splits after translation, this only applies if "level" is "bpe" (default: True)
 
 training:                           # specify training details here
     #load_model: "models/small_model/60.ckpt" # if given, load a pre-trained model from this checkpoint

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -375,7 +375,8 @@ class TrainManager:
                             max_output_length=self.max_output_length,
                             loss_function=self.loss,
                             beam_size=1,  # greedy validations
-                            batch_type=self.eval_batch_type
+                            batch_type=self.eval_batch_type,
+                            postprocess=True # always remove BPE for validation
                         )
 
                     self.tb_writer.add_scalar("valid/valid_loss",


### PR DESCRIPTION
This small PR just adds a config field `postprocess` to let users output translations with BPE splits, instead of always removing them. The default behaviour is still to remove BPE if `level=bpe`.