### PR TITLE
check mask type in TransformerDecoder

### DIFF
--- a/joeynmt/decoders.py
+++ b/joeynmt/decoders.py
@@ -506,6 +506,8 @@ class TransformerDecoder(Decoder):
         :return:
         """
         assert trg_mask is not None, "trg_mask required for Transformer"
+        assert isinstance(src_mask, (torch.BoolTensor, torch.cuda.BoolTensor)), "src_mask has to be of type `BoolTensor`"
+        assert isinstance(trg_mask, (torch.BoolTensor, torch.cuda.BoolTensor)), "trg_mask has to be of type `BoolTensor`"
 
         x = self.pe(trg_embed)  # add position encoding to word embedding
         x = self.emb_dropout(x)

--- a/joeynmt/decoders.py
+++ b/joeynmt/decoders.py
@@ -506,8 +506,10 @@ class TransformerDecoder(Decoder):
         :return:
         """
         assert trg_mask is not None, "trg_mask required for Transformer"
-        assert isinstance(src_mask, (torch.BoolTensor, torch.cuda.BoolTensor)), "src_mask has to be of type `BoolTensor`"
-        assert isinstance(trg_mask, (torch.BoolTensor, torch.cuda.BoolTensor)), "trg_mask has to be of type `BoolTensor`"
+        assert isinstance(src_mask, (torch.BoolTensor, torch.cuda.BoolTensor)),\
+            "src_mask has to be of type `BoolTensor`"
+        assert isinstance(trg_mask, (torch.BoolTensor, torch.cuda.BoolTensor)),\
+            "trg_mask has to be of type `BoolTensor`"
 
         x = self.pe(trg_embed)  # add position encoding to word embedding
         x = self.emb_dropout(x)


### PR DESCRIPTION
While trying to use the `TransformerDecoder` I ran into a problem that all my predication where always `<s>` or `<pad>`. It looks like `src_mask` and `trg_mask` must be of type `BoolTensor`. `ByteTensor` worked for me with the `RecurrentDecoder`.

This error can be reproduced with this code snippet:
```python
device = 'cuda'

batch_size = 2
src_time_dim = 4
trg_time_dim = 5
vocab_size = 7

trg_embed = torch.rand(size=(batch_size, trg_time_dim, self.emb_size)).to(device)

decoder = TransformerDecoder(
    num_layers=self.num_layers, num_heads=self.num_heads,
    hidden_size=self.hidden_size, ff_size=self.ff_size,
    dropout=self.dropout, emb_dropout=self.dropout,
    vocab_size=vocab_size).to(device)

encoder_output = torch.rand(
    size=(batch_size, src_time_dim, self.hidden_size)).to(device)

for p in decoder.parameters():
    torch.nn.init.uniform_(p, -0.5, 0.5).to(device)

src_mask = torch.ones(size=(batch_size, 1, src_time_dim)).byte().to(device)
trg_mask = torch.ones(size=(batch_size, trg_time_dim, 1)).byte().to(device)

output, states, _, _ = decoder(
    trg_embed, encoder_output, None, src_mask, None, None, trg_mask)

print('output', output)
print('states', states)
```

With `device = 'cuda'` this returns: 
```
output tensor([[[nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan]],

        [[nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan]]], device='cuda:0',
       grad_fn=<UnsafeViewBackward>)
states tensor([[[nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan]],

        [[nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan]]],
       device='cuda:0', grad_fn=<NativeLayerNormBackward>)
```

When running the same code on the CPU with `device = 'cpu'` I get an error message and the program halts.

```
scores = scores.masked_fill(~mask.unsqueeze(1), float('-inf'))
RuntimeError: Mask tensor can take 0 and 1 values only
```

Since I used a GPU while developing I never got the error message and just NaNs.


I have added a simple type check for `src_mask` and `trg_mask` in the `forward` function of the `TransformerDecoder` and a unit test to check if the AssertionError is raised.