### PR TITLE
remove tensorflow, only keep tensorboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pillow
 numpy<1.19.0,>=1.14.5 
 setuptools>=41.0.0
 torch>=1.1
-tensorflow>=1.14
+tensorboard>=1.15
 torchtext<0.8.0
 sacrebleu>=1.3.6
 subword-nmt


### PR DESCRIPTION
To my understanding the only part of TensorFlow that is being used is TensorBoard.

Rather than installing the full TensorFlow dependency (`tensorflow-2.3.1-cp36-cp36m-manylinux2010_x86_64.whl (320.4 MB)`) only TensorBoard (`tensorboard-2.3.0-py3-none-any.whl (6.8 MB)`) needs to be installed, saving over 300MB in download and disk space.

Minimum TensorBoard Version for PyTorch is[ 1.15](https://github.com/pytorch/pytorch/blob/90400f48fcebb2fdbc808d2ab14d639f1e6bcf33/torch/utils/tensorboard/__init__.py#L4).