### PR TITLE
fix pack_padded_sequence()

### DIFF
--- a/joeynmt/encoders.py
+++ b/joeynmt/encoders.py
@@ -113,7 +113,7 @@ class RecurrentEncoder(Encoder):
         # apply dropout to the rnn input
         embed_src = self.emb_dropout(embed_src)
 
-        packed = pack_padded_sequence(embed_src, src_length, batch_first=True)
+        packed = pack_padded_sequence(embed_src, src_length.cpu(), batch_first=True)
         output, hidden = self.rnn(packed)
 
         #pylint: disable=unused-variable


### PR DESCRIPTION
Hi!
It seems like for pytorch 1.7.0, pack_padded_sequence's src_length  must be in cpu, even if we're using cuda: https://github.com/pytorch/pytorch/issues/43227

I also tried this command in pytorch 1.6.0 to check for backward compatibility and there it works fine, both with and without adding .cpu()