### PR TITLE
Allow extending the model inputs

### DIFF
--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -106,21 +106,27 @@ class Model(nn.Module):
         return return_tuple
 
     # pylint: disable=arguments-differ
-    def _encode_decode(self, trg_input: Tensor, **kwargs) \
+    def _encode_decode(self, src: Tensor, trg_input: Tensor, src_mask: Tensor,
+                       src_length: Tensor, trg_mask: Tensor = None, **kwargs) \
             -> (Tensor, Tensor, Tensor, Tensor):
         """
         First encodes the source sentence.
         Then produces the target one word at a time.
 
+        :param src: source input
         :param trg_input: target input
+        :param src_mask: source mask
+        :param src_length: length of source inputs
+        :param trg_mask: target mask
         :return: decoder outputs
         """
-        encoder_output, encoder_hidden = self._encode(**kwargs)
+        encoder_output, encoder_hidden = self._encode(src=src, src_length=src_length, src_mask=src_mask, **kwargs)
         unroll_steps = trg_input.size(1)
-        return self._decode(trg_input=trg_input,
-                            encoder_output=encoder_output,
+        return self._decode(encoder_output=encoder_output,
                             encoder_hidden=encoder_hidden,
-                            unroll_steps=unroll_steps, **kwargs)
+                            src_mask=src_mask, trg_input=trg_input,
+                            unroll_steps=unroll_steps,
+                            trg_mask=trg_mask, **kwargs)
 
     def _encode(self, src: Tensor, src_length: Tensor, src_mask: Tensor, **kwargs) \
             -> (Tensor, Tensor):

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -117,7 +117,8 @@ class Model(nn.Module):
         """
         encoder_output, encoder_hidden = self._encode(**kwargs)
         unroll_steps = trg_input.size(1)
-        return self._decode(encoder_output=encoder_output,
+        return self._decode(trg_input=trg_input,
+                            encoder_output=encoder_output,
                             encoder_hidden=encoder_hidden,
                             unroll_steps=unroll_steps, **kwargs)
 

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -120,7 +120,10 @@ class Model(nn.Module):
         :param trg_mask: target mask
         :return: decoder outputs
         """
-        encoder_output, encoder_hidden = self._encode(src=src, src_length=src_length, src_mask=src_mask, **kwargs)
+        encoder_output, encoder_hidden = self._encode(src=src,
+                                                      src_length=src_length,
+                                                      src_mask=src_mask,
+                                                      **kwargs)
         unroll_steps = trg_input.size(1)
         return self._decode(encoder_output=encoder_output,
                             encoder_hidden=encoder_hidden,
@@ -128,8 +131,8 @@ class Model(nn.Module):
                             unroll_steps=unroll_steps,
                             trg_mask=trg_mask, **kwargs)
 
-    def _encode(self, src: Tensor, src_length: Tensor, src_mask: Tensor, **kwargs) \
-            -> (Tensor, Tensor):
+    def _encode(self, src: Tensor, src_length: Tensor, src_mask: Tensor,
+                **_kwargs) -> (Tensor, Tensor):
         """
         Encodes the source sentence.
 
@@ -143,7 +146,7 @@ class Model(nn.Module):
     def _decode(self, encoder_output: Tensor, encoder_hidden: Tensor,
                 src_mask: Tensor, trg_input: Tensor,
                 unroll_steps: int, decoder_hidden: Tensor = None,
-                att_vector: Tensor = None, trg_mask: Tensor = None, **kwargs) \
+                att_vector: Tensor = None, trg_mask: Tensor = None, **_kwargs) \
             -> (Tensor, Tensor, Tensor, Tensor):
         """
         Decode, given an encoded source sentence.

--- a/joeynmt/prediction.py
+++ b/joeynmt/prediction.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # pylint: disable=too-many-arguments,too-many-locals,no-member
 def validate_on_data(model: Model, data: Dataset,
                      batch_size: int,
-                     batch_class,
+                     batch_class: Batch,
                      use_cuda: bool, max_output_length: int,
                      level: str, eval_metric: Optional[str],
                      n_gpu: int,

--- a/joeynmt/prediction.py
+++ b/joeynmt/prediction.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 # pylint: disable=too-many-arguments,too-many-locals,no-member
 def validate_on_data(model: Model, data: Dataset,
                      batch_size: int,
+                     batch_class,
                      use_cuda: bool, max_output_length: int,
                      level: str, eval_metric: Optional[str],
                      n_gpu: int,
@@ -46,6 +47,7 @@ def validate_on_data(model: Model, data: Dataset,
     :param model: model module
     :param data: dataset for validation
     :param batch_size: validation batch size
+    :param batch_class: class type of batch
     :param use_cuda: if True, use CUDA
     :param max_output_length: maximum length for generated hypotheses
     :param level: segmentation level, one of "char", "bpe", "word"
@@ -99,16 +101,13 @@ def validate_on_data(model: Model, data: Dataset,
         for valid_batch in iter(valid_iter):
             # run as during training to get validation loss (e.g. xent)
 
-            batch = Batch(valid_batch, pad_index, use_cuda=use_cuda)
+            batch = batch_class(valid_batch, pad_index, use_cuda=use_cuda)
             # sort batch now by src length and keep track of order
             sort_reverse_index = batch.sort_by_src_length()
 
             # run as during training with teacher forcing
             if compute_loss and batch.trg is not None:
-                batch_loss, _, _, _ = model(
-                    return_type="loss", src=batch.src, trg=batch.trg,
-                    trg_input=batch.trg_input, trg_mask=batch.trg_mask,
-                    src_mask=batch.src_mask, src_length=batch.src_length)
+                batch_loss, _, _, _ = model(return_type="loss", **vars(batch))
                 if n_gpu > 1:
                     batch_loss = batch_loss.mean() # average on multi-gpu
                 total_loss += batch_loss
@@ -283,7 +282,7 @@ def test(cfg_file,
         _, dev_data, test_data, src_vocab, trg_vocab = load_data(
             data_cfg=cfg["data"], datasets=["dev", "test"])
         data_to_predict = {"dev": dev_data, "test": test_data}
-    else:   # avoid to load data again
+    else:  # avoid to load data again
         data_to_predict = {"dev": datasets["dev"], "test": datasets["test"]}
         src_vocab = datasets["src_vocab"]
         trg_vocab = datasets["trg_vocab"]

--- a/joeynmt/search.py
+++ b/joeynmt/search.py
@@ -426,7 +426,8 @@ def run_batch(model: Model, batch: Batch, max_output_length: int,
         stacked_attention_scores: attention scores for batch
     """
     with torch.no_grad():
-        encoder_output, encoder_hidden, _, _ = model(return_type="encode", **vars(batch))
+        encoder_output, encoder_hidden, _, _ = model(
+            return_type="encode", **vars(batch))
 
     # if maximum output length is not globally specified, adapt to src len
     if max_output_length is None:

--- a/joeynmt/search.py
+++ b/joeynmt/search.py
@@ -426,10 +426,7 @@ def run_batch(model: Model, batch: Batch, max_output_length: int,
         stacked_attention_scores: attention scores for batch
     """
     with torch.no_grad():
-        encoder_output, encoder_hidden, _, _ = model(
-            return_type="encode", src=batch.src,
-            src_length=batch.src_length,
-            src_mask=batch.src_mask)
+        encoder_output, encoder_hidden, _, _ = model(return_type="encode", **vars(batch))
 
     # if maximum output length is not globally specified, adapt to src len
     if max_output_length is None:

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -50,7 +50,8 @@ class TrainManager:
     """ Manages training loop, validations, learning rate scheduling
     and early stopping."""
 
-    def __init__(self, model: Model, config: dict, batch_class: Batch=Batch) -> None:
+    def __init__(self, model: Model, config: dict,
+                 batch_class: Batch = Batch) -> None:
         """
         Creates a new TrainManager for a model, specified as in configuration.
 

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -50,7 +50,7 @@ class TrainManager:
     """ Manages training loop, validations, learning rate scheduling
     and early stopping."""
 
-    def __init__(self, model: Model, config: dict, batch_class) -> None:
+    def __init__(self, model: Model, config: dict, batch_class: Batch=Batch) -> None:
         """
         Creates a new TrainManager for a model, specified as in configuration.
 

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -50,7 +50,7 @@ class TrainManager:
     """ Manages training loop, validations, learning rate scheduling
     and early stopping."""
 
-    def __init__(self, model: Model, config: dict, batch_class=Batch) -> None:
+    def __init__(self, model: Model, config: dict, batch_class) -> None:
         """
         Creates a new TrainManager for a model, specified as in configuration.
 
@@ -502,6 +502,7 @@ class TrainManager:
         valid_hypotheses_raw, valid_attention_scores = \
             validate_on_data(
                 batch_size=self.eval_batch_size,
+                batch_class=self.batch_class,
                 data=valid_data,
                 eval_metric=self.eval_metric,
                 level=self.level, model=self.model,


### PR DESCRIPTION
Change to implicit parameter passing.
It's a large change, so happy to discuss this :)



Currently, many of the dataset parameters are hardcoded and explicitly stated when passed to functions.
This, in my opinion, and experience hurts the ability to use `joeynmt` as a library, and extend to use different inputs, or multiple inputs, like images, audio, etc...

This PR does not remove the `src` and `trg` sequences from being text sequences but allows for extending and adding more inputs. 
For example, for every word in `src` I have some features, like its `POS` tag which I'd like to use. Currently, I can't. With this PR, I'll have to change the data loader and just extend the `Batch` class. Not many changes and I can use more inputs.


## Failed checks
At its current state, it fails linting because of unused argument `kwargs`. In my opinion it is ok if its unused, because it allows anyone to extend the base translation class. 
One way to fix this is to add a pylint "suppress" on each of those lines, but I want to know what you think first