### PR TITLE
Fix for Continuing training from checkpoint is different than uninterupted training #125 

### DIFF
--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -66,6 +66,7 @@ training:                           # specify training details here
     print_valid_sents: [0, 1, 2]    # print this many validation sentences during each validation run, default: [0, 1, 2]
     keep_last_ckpts: 3              # keep this many of the latest checkpoints, if -1: all of them, default: 5
     label_smoothing: 0.0            # label smoothing: reference tokens will have 1-label_smoothing probability instead of 1, rest of probability mass is uniformly distributed over the rest of the vocabulary, default: 0.0 (off)
+    save_latest_ckpt: True          # this options saves a checkpoint every validation run, even if it wasn't the best, and then deletes the previous checkpoint.
 
 model:                              # specify your model architecture here
     initializer: "xavier"           # initializer for all trainable weights (xavier, zeros, normal, uniform)

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -22,7 +22,7 @@ Training
 ^^^^^^^^
 
 - **How can I train the model on GPU/CPU?**
-   First of all, make sure you have the correct version of pytorch installed. 
+   First of all, make sure you have the correct version of pytorch installed.
    When running on *GPU* you need to manually install the suitable PyTorch version for your `CUDA <https://developer.nvidia.com/cuda-zone>`_ version. This is described in the `PyTorch installation instructions <https://pytorch.org/get-started/locally/>`_.
    Then set the ``use_cuda`` flag in the configuration to True for training on GPU (requires CUDA) or to False for training on CPU.
 
@@ -58,21 +58,21 @@ Training
 
 - **How can I perform domain adaptation or fine-tuning?**
    Both approaches are similar, so we call the fine-tuning data *in-domain* data in the following.
-   
+
      1. First train your model on one dataset (the *out-of-domain* data).
-   
+
      2. Modify the original configuration file (or better a copy of it) in the data section to point to the new *in-domain* data.
         Specify which vocabularies to use: ``src_vocab: out-of-domain-model/src_vocab.txt`` and likewise for ``trg_vocab``.
         You have to specify this, otherwise JoeyNMT will try to build a new vocabulary from the new in-domain data, which the out-of-domain model wasn't built with.
         In the training section, specify which checkpoint of the out-of-domain model you want to start adapting: ``load_model: out-of-domain-model/best.ckpt``.
         If you set ``reset_best_ckpt'': True'', previously stored high scores under your metric will be ignored, and if you set ``reset_scheduler'' and ``reset_optimizer'' you can also overwrite the stored scheduler and optimizer with the new ones in your configuration.
         Use this if the scores on your new dev set are lower than on the old dev set, or if you use a different metric or schedule for fine-tuning.
-    
+
      3. Train the in-domain model.
 
 - **What if training is interrupted and I need to resume it?**
    Modify the configuration to load the latest checkpoint (``load_model``) and the vocabularies (``src_vocab``, ``trg_vocab``) and to write the model into a new directory (``model_dir``).
-   Then train with this configuration.
+   Then train with this configuration. Joey can be configured to save the checkpoint after every validation run, ensuring that you don't have to resume training from an old checkpoint. This can be enabled by setting ``save_latest_ckpt`` to ``True`` in your config file.
 
 
 Tuning
@@ -229,12 +229,12 @@ Model Extensions
     Logging and unit tests are very useful tools for tracking the changes of your implementation as well.
 
 - **How do I integrate a new learning rate scheduler?**
-    1. Check out the existing schedulers in `builders.py <https://github.com/joeynmt/joeynmt/blob/master/joeynmt/builders.py>`_, some of them are imported from PyTorch. The "Noam" scheduler is implemented here directly, you can use its code as a template how to implement a new scheduler. 
-  
+    1. Check out the existing schedulers in `builders.py <https://github.com/joeynmt/joeynmt/blob/master/joeynmt/builders.py>`_, some of them are imported from PyTorch. The "Noam" scheduler is implemented here directly, you can use its code as a template how to implement a new scheduler.
+
     2. You basically need to implement the ``step`` function that implements whatever happens when the scheduler is asked to make a step (either after every validation (``scheduler_step_at="validation"``) or every batch (``scheduler_step_at="step"``)). In that step, the learning rate can be modified just as you like (``rate = self._compute_rate()``). In order to make an effective update of the learning rate, the learning rate for the optimizer's parameter groups have to be set to the new value (``for p in self.optimizer.param_groups: p['lr'] = rate``).
-  
+
     3. The last thing that is missing is the parsing of configuration parameters to build the scheduler object. Once again, follow the example of existing schedulers and integrate the code for constructing your new scheduler in the ``build_scheduler`` function.
-  
+
     4. Give the new scheduler a try! Integrate it in a basic configuration file and check in the training log and the validation reports whether the learning rate is behaving as desired.
 
 
@@ -268,17 +268,17 @@ Contributing
 Evaluation
 ----------
 - **Which quality metrics does JoeyNMT report?**
-    JoeyNMT reports `BLEU <https://www.aclweb.org/anthology/P02-1040.pdf>`_, `chrF <https://www.aclweb.org/anthology/W15-3049.pdf>`_, sentence- and token-level accuracy. You can choose which of those to report with setting `eval_metric` accordingly. As a default, we recommend BLEU since it is a standard metric. However, not all BLEU implementations compute the score in the same way, as discussed `in this paper by Matt Post <https://www.aclweb.org/anthology/W18-6319/>`_. So the scores that you obtain might not be comparable to those published in a paper, *even* if the data is identical! 
-    
+    JoeyNMT reports `BLEU <https://www.aclweb.org/anthology/P02-1040.pdf>`_, `chrF <https://www.aclweb.org/anthology/W15-3049.pdf>`_, sentence- and token-level accuracy. You can choose which of those to report with setting `eval_metric` accordingly. As a default, we recommend BLEU since it is a standard metric. However, not all BLEU implementations compute the score in the same way, as discussed `in this paper by Matt Post <https://www.aclweb.org/anthology/W18-6319/>`_. So the scores that you obtain might not be comparable to those published in a paper, *even* if the data is identical!
+
 - **Which library is JoeyNMT using to compute BLEU scores?**
     JoeyNMT uses `sacrebleu <ttps://github.com/mjpost/sacrebleu>`_ to compute BLEU and chrF scores.
     It uses the `raw_corpus_bleu <https://github.com/mjpost/sacrebleu/blob/f54908ac00879f666c92f4174367bcd3a8723197/sacrebleu/sacrebleu.py#L653>`_ scoring function that excludes special de/tokenization or smoothing. This is done to respect the tokenization that is inherent in the provided input data. However, that means that the BLEU score you get out of Joey is *dependent on your input tokenization*, so be careful when comparing it to scores you find in literature.
-    
+
 - **Can I publish the BLEU scores JoeyNMT reports on my test set?**
     As described in the two preceding questions, BLEU reporting has to be handled with care, since it depends on tokenizers and implementations. Generally, whenever you report BLEU scores, report as well how you computed them. This is essential for reproducability of results and future comparisons. If you compare to previous benchmarks or scores, first find out how these were computed.
     Our recommendation is as follows:
-      1. Use the scores that Joey reports on your validation set for tuning and selecting the best model. 
+      1. Use the scores that Joey reports on your validation set for tuning and selecting the best model.
       2. Then translate your test set once (in "translate" mode), and post-process the produced translations accordingly, e.g., detokenize it, restore casing.
       3. Use the BLEU scoring library of your choice, this is the one that is reported in previous benchmarks, or e.g. sacrebleu (see above). Make sure to set tokenization flags correctly.
-      4. Report these scores together with a description of how you computed them, ideally provide a script with your code.  
+      4. Report these scores together with a description of how you computed them, ideally provide a script with your code.
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -81,7 +81,7 @@ We chose to largely adopt the `implementation of beam search in OpenNMT-py <http
 Checkpoints
 ===========
 The TrainManager takes care of saving checkpoints whenever the model has reached a new validation highscore (keeping a configurable number of checkpoints in total).
-The checkpoints do not only contain the model parameters (``model_state``), but also the cumulative count of training tokens and steps, the highscore and iteration count for that highscore, the state of the optimizer and the scheduler.
+The checkpoints do not only contain the model parameters (``model_state``), but also the cumulative count of training tokens and steps, the highscore and iteration count for that highscore, the state of the optimizer, the scheduler and the data iterator.
 This ensures a seamless continuation of training when training is interrupted.
 
 From ``_save_checkpoint``:
@@ -99,6 +99,7 @@ From ``_save_checkpoint``:
         "scheduler_state": self.scheduler.state_dict() if \
         self.scheduler is not None else None,
         'amp_state': amp.state_dict() if self.fp16 else None
+        'train_iter_state': train_iter.state_dict()
     }
 
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -118,7 +118,7 @@ Here we're using the "plateau" scheduler that reduces the initial learning rate 
 Validations (with greedy decoding) are performed every ``validation_freq`` batches and every ``logging_freq`` batches the training batch loss will be logged.
 
 Checkpoints for the model parameters are saved whenever a new high score in ``early_stopping_metric``, here the ``eval_metric`` BLEU, has been reached.
-In order to not waste much memory on old checkpoints, we're only keeping the ``keep_last_ckpts`` last checkpoints.
+In order to not waste much memory on old checkpoints, we're only keeping the ``keep_last_ckpts`` best checkpoints. We can also always keep the latest checkpoint by setting ``save_latest_ckpt`` to ``True``. This will keep the latest checkpoint and delete the previous checkpoint as necessary.
 
 At the beginning of each epoch the training data is shuffled if we set ``shuffle`` to True (there is actually no good reason for not doing so).
 

--- a/joeynmt/encoders.py
+++ b/joeynmt/encoders.py
@@ -113,7 +113,8 @@ class RecurrentEncoder(Encoder):
         # apply dropout to the rnn input
         embed_src = self.emb_dropout(embed_src)
 
-        packed = pack_padded_sequence(embed_src, src_length.cpu(), batch_first=True)
+        packed = pack_padded_sequence(embed_src, src_length.cpu(),
+                                      batch_first=True)
         output, hidden = self.rnn(packed)
 
         #pylint: disable=unused-variable

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -335,7 +335,7 @@ def symlink_update(target, link_name):
 
 
 def latest_checkpoint_update(target: pathlib.Path,
-                             link_name: str) -> pathlib.Path:
+                             link_name: str) -> Optional[pathlib.Path]:
     link = pathlib.Path(link_name)
     if link.is_symlink():
         current_last = link.resolve()

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -56,7 +56,7 @@ def make_logger(log_dir: str = None, mode: str = "train") -> str:
     :return: joeynmt version number
     """
     logger = logging.getLogger("")  # root logger
-    version = '1.0.0'  #pkg_resources.require("joeynmt")[0].version
+    version = pkg_resources.require("joeynmt")[0].version
 
     # add handlers only once.
     if len(logger.handlers) == 0:
@@ -159,12 +159,10 @@ def log_data_info(train_data: Dataset, valid_data: Dataset, test_data: Dataset,
 
     logger.info(
         "First 10 words (src): %s",
-        " ".join('(%d) %s' % (i, t)
-                 for i, t in enumerate(src_vocab.itos[:10])))
+        " ".join('(%d) %s' % (i, t) for i, t in enumerate(src_vocab.itos[:10])))
     logger.info(
         "First 10 words (trg): %s",
-        " ".join('(%d) %s' % (i, t)
-                 for i, t in enumerate(trg_vocab.itos[:10])))
+        " ".join('(%d) %s' % (i, t) for i, t in enumerate(trg_vocab.itos[:10])))
 
     logger.info("Number of Src words (types): %d", len(src_vocab))
     logger.info("Number of Trg words (types): %d", len(trg_vocab))
@@ -344,6 +342,5 @@ def latest_checkpoint_update(target: pathlib.Path,
         link.unlink()
         link.symlink_to(target)
         return current_last
-    else:
-        link.symlink_to(target)
-        return None
+    link.symlink_to(target)
+    return None

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -336,6 +336,18 @@ def symlink_update(target, link_name):
 
 def latest_checkpoint_update(target: pathlib.Path,
                              link_name: str) -> Optional[pathlib.Path]:
+    """
+    This function finds the file that the symlink currently points to, sets it
+    to the new target, and returns the previous target if it exists.
+
+    :param target: A path to a file that we want the symlink to point to.
+    :param link_name: This is the name of the symlink that we want to update.
+
+    :return:
+        - current_last: This is the previous target of the symlink, before it is
+            updated in this function. If the symlink did not exist before or did
+            not have a target, None is returned instead.
+    """
     link = pathlib.Path(link_name)
     if link.is_symlink():
         current_last = link.resolve()

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -24,7 +24,8 @@ from joeynmt.model import build_model
 from joeynmt.batch import Batch
 from joeynmt.helpers import log_data_info, load_config, log_cfg, \
     store_attention_plots, load_checkpoint, make_model_dir, \
-    make_logger, set_seed, symlink_update, latest_checkpoint_update, ConfigurationError
+    make_logger, set_seed, symlink_update, latest_checkpoint_update, \
+    ConfigurationError
 from joeynmt.model import Model, _DataParallel
 from joeynmt.prediction import validate_on_data
 from joeynmt.loss import XentLoss
@@ -48,6 +49,7 @@ logger = logging.getLogger(__name__)
 class TrainManager:
     """ Manages training loop, validations, learning rate scheduling
     and early stopping."""
+
     def __init__(self, model: Model, config: dict) -> None:
         """
         Creates a new TrainManager for a model, specified as in configuration.
@@ -63,8 +65,7 @@ class TrainManager:
 
         self.logging_freq = train_config.get("logging_freq", 100)
         self.valid_report_file = "{}/validations.txt".format(self.model_dir)
-        self.tb_writer = SummaryWriter(log_dir=self.model_dir +
-                                       "/tensorboard/")
+        self.tb_writer = SummaryWriter(log_dir=self.model_dir + "/tensorboard/")
 
         self.save_latest_checkpoint = train_config.get("save_latest_ckpt",
                                                        False)
@@ -225,24 +226,24 @@ class TrainManager:
             else self.model.state_dict()
         state = {
             "steps":
-            self.stats.steps,
+                self.stats.steps,
             "total_tokens":
-            self.stats.total_tokens,
+                self.stats.total_tokens,
             "best_ckpt_score":
-            self.stats.best_ckpt_score,
+                self.stats.best_ckpt_score,
             "best_ckpt_iteration":
-            self.stats.best_ckpt_iter,
+                self.stats.best_ckpt_iter,
             "model_state":
-            model_state_dict,
+                model_state_dict,
             "optimizer_state":
-            self.optimizer.state_dict(),
+                self.optimizer.state_dict(),
             "scheduler_state":
-            self.scheduler.state_dict()
-            if self.scheduler is not None else None,
+                self.scheduler.state_dict()
+                if self.scheduler is not None else None,
             'amp_state':
-            amp.state_dict() if self.fp16 else None,
+                amp.state_dict() if self.fp16 else None,
             "train_iter_state":
-            self.train_iter.state_dict()
+                self.train_iter.state_dict()
         }
         torch.save(state, model_path)
         symlink_target = "{}.ckpt".format(self.stats.steps)
@@ -330,8 +331,8 @@ class TrainManager:
         else:
             logger.info("Reset tracking of the best checkpoint.")
 
-        if (not reset_iter_state and model_checkpoint.get(
-                'train_iter_state', None) is not None):
+        if (not reset_iter_state and
+                model_checkpoint.get('train_iter_state', None) is not None):
             self.train_iter_state = model_checkpoint["train_iter_state"]
 
         # move parameters to cuda
@@ -520,9 +521,8 @@ class TrainManager:
         elif self.normalization == "none":
             normalizer = 1
         else:
-            raise NotImplementedError(
-                "Only normalize by 'batch' or 'tokens' "
-                "or summation of loss 'none' implemented")
+            raise NotImplementedError("Only normalize by 'batch' or 'tokens' "
+                                      "or summation of loss 'none' implemented")
 
         norm_batch_loss = batch_loss / normalizer
 
@@ -531,8 +531,7 @@ class TrainManager:
 
         # accumulate gradients
         if self.fp16:
-            with amp.scale_loss(norm_batch_loss,
-                                self.optimizer) as scaled_loss:
+            with amp.scale_loss(norm_batch_loss, self.optimizer) as scaled_loss:
                 scaled_loss.backward()
         else:
             norm_batch_loss.backward()
@@ -612,9 +611,8 @@ class TrainManager:
         logger.info(
             'Validation result (greedy) at epoch %3d, '
             'step %8d: %s: %6.2f, loss: %8.4f, ppl: %8.4f, '
-            'duration: %.4fs', epoch_no + 1, self.stats.steps,
-            self.eval_metric, valid_score, valid_loss, valid_ppl,
-            valid_duration)
+            'duration: %.4fs', epoch_no + 1, self.stats.steps, self.eval_metric,
+            valid_score, valid_loss, valid_ppl, valid_duration)
 
         # store validation set outputs
         self._store_outputs(valid_hypotheses)
@@ -717,13 +715,14 @@ class TrainManager:
 
         :param hypotheses: list of strings
         """
-        current_valid_output_file = "{}/{}.hyps".format(
-            self.model_dir, self.stats.steps)
+        current_valid_output_file = "{}/{}.hyps".format(self.model_dir,
+                                                        self.stats.steps)
         with open(current_valid_output_file, 'w') as opened_file:
             for hyp in hypotheses:
                 opened_file.write("{}\n".format(hyp))
 
     class TrainStatistics:
+
         def __init__(self,
                      steps: int = 0,
                      stop: bool = False,

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -49,7 +49,6 @@ logger = logging.getLogger(__name__)
 class TrainManager:
     """ Manages training loop, validations, learning rate scheduling
     and early stopping."""
-
     def __init__(self, model: Model, config: dict) -> None:
         """
         Creates a new TrainManager for a model, specified as in configuration.
@@ -67,8 +66,7 @@ class TrainManager:
         self.valid_report_file = "{}/validations.txt".format(self.model_dir)
         self.tb_writer = SummaryWriter(log_dir=self.model_dir + "/tensorboard/")
 
-        self.save_latest_checkpoint = train_config.get("save_latest_ckpt",
-                                                       False)
+        self.save_latest_checkpoint = train_config.get("save_latest_ckpt", True)
 
         # model
         self.model = model
@@ -218,6 +216,8 @@ class TrainManager:
         the best checkpoint score and iteration so far,
         and optimizer and scheduler states.
 
+        :param new_best: This boolean signals which symlink we will use for the
+          new checkpoint. If it is true, we update best.ckpt, else latest.ckpt.
         """
         model_path = os.path.join(self.model_dir,
                                   "{}.ckpt".format(self.stats.steps))
@@ -226,24 +226,23 @@ class TrainManager:
             else self.model.state_dict()
         state = {
             "steps":
-                self.stats.steps,
+            self.stats.steps,
             "total_tokens":
-                self.stats.total_tokens,
+            self.stats.total_tokens,
             "best_ckpt_score":
-                self.stats.best_ckpt_score,
+            self.stats.best_ckpt_score,
             "best_ckpt_iteration":
-                self.stats.best_ckpt_iter,
+            self.stats.best_ckpt_iter,
             "model_state":
-                model_state_dict,
+            model_state_dict,
             "optimizer_state":
-                self.optimizer.state_dict(),
+            self.optimizer.state_dict(),
             "scheduler_state":
-                self.scheduler.state_dict()
-                if self.scheduler is not None else None,
+            self.scheduler.state_dict() if self.scheduler is not None else None,
             'amp_state':
-                amp.state_dict() if self.fp16 else None,
+            amp.state_dict() if self.fp16 else None,
             "train_iter_state":
-                self.train_iter.state_dict()
+            self.train_iter.state_dict()
         }
         torch.save(state, model_path)
         symlink_target = "{}.ckpt".format(self.stats.steps)
@@ -300,7 +299,7 @@ class TrainManager:
         :param reset_optimizer: reset the optimizer, and do not use the one
                                 stored in the checkpoint.
         :param reset_iter_state: reset the sampler's internal state and do not
-                                use the one store3d in the checkpoint.
+                                use the one stored in the checkpoint.
         """
         logger.info("Loading model from %s", path)
         model_checkpoint = load_checkpoint(path=path, use_cuda=self.use_cuda)
@@ -331,8 +330,8 @@ class TrainManager:
         else:
             logger.info("Reset tracking of the best checkpoint.")
 
-        if (not reset_iter_state and
-                model_checkpoint.get('train_iter_state', None) is not None):
+        if (not reset_iter_state
+                and model_checkpoint.get('train_iter_state', None) is not None):
             self.train_iter_state = model_checkpoint["train_iter_state"]
 
         # move parameters to cuda
@@ -722,7 +721,6 @@ class TrainManager:
                 opened_file.write("{}\n".format(hyp))
 
     class TrainStatistics:
-
         def __init__(self,
                      steps: int = 0,
                      stop: bool = False,


### PR DESCRIPTION
This fixes the issue raised in #125 by saving the train_iter state in the checkpoint and restoring it when continuing from that checkpoint. This also adds an option to always save the latest checkpoint, so that if training is interrupted by a job scheduler, you can resume exactly as training left off making it comparable to uninterrupted training. This will be helpful when people train models on google colab or other shared computing resources with time outs.

I did notice that my IDE autoformatted the rest of the code, so I can add my changes to the original formatting or we could adopt a style guide.