### PR TITLE
fix RNN Multi GPU error

### DIFF
--- a/joeynmt/batch.py
+++ b/joeynmt/batch.py
@@ -3,13 +3,14 @@
 """
 Implementation of a mini-batch.
 """
+import torch
 
 
 class Batch:
     """Object for holding a batch of data with mask during training.
     Input is a batch from a torch text iterator.
     """
-
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, torch_batch, pad_index, use_cuda=False):
         """
         Create a new joey batch from a torch batch.
@@ -30,6 +31,7 @@ class Batch:
         self.trg_length = None
         self.ntokens = None
         self.use_cuda = use_cuda
+        self.device = torch.device("cuda" if self.use_cuda else "cpu")
 
         if hasattr(torch_batch, "trg"):
             trg, trg_length = torch_batch.trg
@@ -42,7 +44,7 @@ class Batch:
             self.trg_mask = (self.trg_input != pad_index).unsqueeze(1)
             self.ntokens = (self.trg != pad_index).data.sum().item()
 
-        if use_cuda:
+        if self.use_cuda:
             self._make_cuda()
 
     def _make_cuda(self):
@@ -51,14 +53,14 @@ class Batch:
 
         :return:
         """
-        self.src = self.src.cuda()
-        self.src_mask = self.src_mask.cuda()
-        self.src_length = self.src_length.cuda()
+        self.src = self.src.to(self.device)
+        self.src_mask = self.src_mask.to(self.device)
+        self.src_length = self.src_length.to(self.device)
 
         if self.trg_input is not None:
-            self.trg_input = self.trg_input.cuda()
-            self.trg = self.trg.cuda()
-            self.trg_mask = self.trg_mask.cuda()
+            self.trg_input = self.trg_input.to(self.device)
+            self.trg = self.trg.to(self.device)
+            self.trg_mask = self.trg_mask.to(self.device)
 
     def sort_by_src_length(self):
         """

--- a/joeynmt/encoders.py
+++ b/joeynmt/encoders.py
@@ -51,7 +51,6 @@ class RecurrentEncoder(Encoder):
         :param freeze: freeze the parameters of the encoder during training
         :param kwargs:
         """
-
         super().__init__()
 
         self.emb_dropout = torch.nn.Dropout(p=emb_dropout, inplace=False)
@@ -87,8 +86,8 @@ class RecurrentEncoder(Encoder):
         assert len(src_length.shape) == 1
 
     #pylint: disable=arguments-differ
-    def forward(self, embed_src: Tensor, src_length: Tensor, mask: Tensor) \
-            -> (Tensor, Tensor):
+    def forward(self, embed_src: Tensor, src_length: Tensor, mask: Tensor,
+                **kwargs) -> (Tensor, Tensor):
         """
         Applies a bidirectional RNN to sequence of embeddings x.
         The input mini-batch x needs to be sorted by src length.
@@ -109,6 +108,7 @@ class RecurrentEncoder(Encoder):
         self._check_shapes_input_forward(embed_src=embed_src,
                                          src_length=src_length,
                                          mask=mask)
+        total_length = embed_src.size(1)
 
         # apply dropout to the rnn input
         embed_src = self.emb_dropout(embed_src)
@@ -121,7 +121,8 @@ class RecurrentEncoder(Encoder):
         if isinstance(hidden, tuple):
             hidden, memory_cell = hidden
 
-        output, _ = pad_packed_sequence(output, batch_first=True)
+        output, _ = pad_packed_sequence(output, batch_first=True,
+                                        total_length=total_length)
         # hidden: dir*layers x batch x hidden
         # output: batch x max_length x directions*hidden
         batch_size = hidden.size()[1]
@@ -195,7 +196,7 @@ class TransformerEncoder(Encoder):
     def forward(self,
                 embed_src: Tensor,
                 src_length: Tensor,
-                mask: Tensor) -> (Tensor, Tensor):
+                mask: Tensor, **kwargs) -> (Tensor, Tensor):
         """
         Pass the input (and mask) through each layer in turn.
         Applies a Transformer encoder to sequence of embeddings x.

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -124,7 +124,9 @@ class Model(nn.Module):
                                                       src_length=src_length,
                                                       src_mask=src_mask,
                                                       **kwargs)
+
         unroll_steps = trg_input.size(1)
+        assert "decoder_hidden" not in kwargs.keys()
         return self._decode(encoder_output=encoder_output,
                             encoder_hidden=encoder_hidden,
                             src_mask=src_mask, trg_input=trg_input,
@@ -141,7 +143,8 @@ class Model(nn.Module):
         :param src_mask:
         :return: encoder outputs (output, hidden_concat)
         """
-        return self.encoder(self.src_embed(src), src_length, src_mask)
+        return self.encoder(self.src_embed(src), src_length, src_mask,
+                            **_kwargs)
 
     def _decode(self, encoder_output: Tensor, encoder_hidden: Tensor,
                 src_mask: Tensor, trg_input: Tensor,
@@ -168,7 +171,8 @@ class Model(nn.Module):
                             unroll_steps=unroll_steps,
                             hidden=decoder_hidden,
                             prev_att_vector=att_vector,
-                            trg_mask=trg_mask)
+                            trg_mask=trg_mask,
+                            **_kwargs)
 
     def __repr__(self) -> str:
         """

--- a/joeynmt/prediction.py
+++ b/joeynmt/prediction.py
@@ -240,7 +240,7 @@ def parse_test_args(cfg, mode="test"):
     tokenizer_info = f"[{sacrebleu['tokenize']}]" \
         if eval_metric == "bleu" else ""
 
-    return batch_size, batch_type, use_cuda, n_gpu, level, \
+    return batch_size, batch_type, use_cuda, device, n_gpu, level, \
            eval_metric, max_output_length, beam_size, beam_alpha, \
            postprocess, bpe_type, sacrebleu, decoding_description, \
            tokenizer_info
@@ -288,7 +288,7 @@ def test(cfg_file,
         trg_vocab = datasets["trg_vocab"]
 
     # parse test args
-    batch_size, batch_type, use_cuda, n_gpu, level, eval_metric, \
+    batch_size, batch_type, use_cuda, device, n_gpu, level, eval_metric, \
         max_output_length, beam_size, beam_alpha, postprocess, \
         bpe_type, sacrebleu, decoding_description, tokenizer_info \
         = parse_test_args(cfg, mode="test")
@@ -301,7 +301,7 @@ def test(cfg_file,
     model.load_state_dict(model_checkpoint["model_state"])
 
     if use_cuda:
-        model.cuda()
+        model.to(device)
 
     # multi-gpu eval
     if n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
@@ -433,7 +433,7 @@ def translate(cfg_file: str, ckpt: str, output_path: str = None) -> None:
     src_field.vocab = src_vocab
 
     # parse test args
-    batch_size, batch_type, use_cuda, n_gpu, level, _, \
+    batch_size, batch_type, use_cuda, device, n_gpu, level, _, \
         max_output_length, beam_size, beam_alpha, postprocess, \
         bpe_type, sacrebleu, _, _ = parse_test_args(cfg, mode="translate")
 
@@ -445,7 +445,7 @@ def translate(cfg_file: str, ckpt: str, output_path: str = None) -> None:
     model.load_state_dict(model_checkpoint["model_state"])
 
     if use_cuda:
-        model.cuda()
+        model.to(device)
 
     if not sys.stdin.isatty():
         # input file given

--- a/joeynmt/prediction.py
+++ b/joeynmt/prediction.py
@@ -201,8 +201,11 @@ def parse_test_args(cfg, mode="test"):
     device = torch.device("cuda" if use_cuda else "cpu")
     if mode == 'test':
         n_gpu = torch.cuda.device_count() if use_cuda else 0
-        logger.info("Process device: %s, n_gpu: %d, batch_size per device: %d",
-            device, n_gpu, batch_size // n_gpu if n_gpu > 1 else batch_size)
+        k = cfg["testing"].get("beam_size", 1)
+        batch_per_device = batch_size*k // n_gpu if n_gpu > 1 else batch_size*k
+        logger.info("Process device: %s, n_gpu: %d, "
+                    "batch_size per device: %d (with beam_size)",
+                    device, n_gpu, batch_per_device)
         eval_metric = cfg["training"]["eval_metric"]
 
     elif mode == 'translate':

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -462,9 +462,9 @@ class TrainManager:
         # get loss
         batch_loss, _, _, _ = self.model(return_type="loss", **vars(batch))
 
-        # average on multi-gpu parallel training
+        # sum multi-gpu losses
         if self.n_gpu > 1:
-            batch_loss = batch_loss.mean()
+            batch_loss = batch_loss.sum()
 
         # normalize batch loss
         if self.normalization == "batch":
@@ -479,6 +479,9 @@ class TrainManager:
                 "or summation of loss 'none' implemented")
 
         norm_batch_loss = batch_loss / normalizer
+
+        if self.n_gpu > 1:
+            norm_batch_loss = norm_batch_loss / self.n_gpu
 
         if self.batch_multiplier > 1:
             norm_batch_loss = norm_batch_loss / self.batch_multiplier

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -169,7 +169,7 @@ class TrainManager:
         self.n_gpu = torch.cuda.device_count() if self.use_cuda else 0
         self.device = torch.device("cuda" if self.use_cuda else "cpu")
         if self.use_cuda:
-            self.model.cuda()
+            self.model.to(self.device)
 
         # fp16
         self.fp16 = train_config.get("fp16", False)
@@ -300,7 +300,7 @@ class TrainManager:
 
         # move parameters to cuda
         if self.use_cuda:
-            self.model.cuda()
+            self.model.to(self.device)
 
         # fp16
         if self.fp16 and model_checkpoint.get("amp_state", None) is not None:

--- a/test/unit/test_decoder.py
+++ b/test/unit/test_decoder.py
@@ -193,20 +193,19 @@ class TestRecurrentDecoder(TensorTestCase):
         self.assertEqual(output.shape, torch.Size(
             [batch_size, time_dim, self.vocab_size]))
         self.assertEqual(hidden.shape, torch.Size(
-            [self.num_layers, batch_size, self.hidden_size]))
+            [batch_size, self.num_layers, self.hidden_size]))
         self.assertEqual(att_probs.shape, torch.Size(
             [batch_size, time_dim, time_dim]))
         self.assertEqual(att_vectors.shape, torch.Size(
             [batch_size, time_dim, self.hidden_size]))
         hidden_target = torch.Tensor(
-            [[[0.1814, 0.5468, -0.4717, -0.7580, 0.5834, -0.4018],
-             [0.1814, 0.5468, -0.4717, -0.7580, 0.5834, -0.4018]],
+            [[[ 0.1814,  0.5468, -0.4717, -0.7580,  0.5834, -0.4018],
+              [ 0.4649,  0.5484, -0.2702,  0.4545,  0.1983,  0.2771],
+              [-0.1752, -0.4215,  0.1941, -0.3975, -0.2317, -0.5566]],
 
-            [[0.4649, 0.5484, -0.2702, 0.4545, 0.1983, 0.2771],
-             [0.4649, 0.5484, -0.2702, 0.4545, 0.1983, 0.2771]],
-
-            [[-0.1752, -0.4215, 0.1941, -0.3975, -0.2317, -0.5566],
-             [-0.1752, -0.4215, 0.1941, -0.3975, -0.2317, -0.5566]]])
+             [[ 0.1814,  0.5468, -0.4717, -0.7580,  0.5834, -0.4018],
+              [ 0.4649,  0.5484, -0.2702,  0.4545,  0.1983,  0.2771],
+              [-0.1752, -0.4215,  0.1941, -0.3975, -0.2317, -0.5566]]])
         output_target = torch.Tensor(
             [[[ 0.2702, -0.1988, -0.1985, -0.2998, -0.2564],
              [ 0.2719, -0.2075, -0.2017, -0.2988, -0.2595],


### PR DESCRIPTION
- [fix #54] .cuda() -> .to(torch.device('cuda'))
- [fix bug] change loss normalization in multi-gpu
- [fix #117] RNN Multi GPU error

---

Note: The main problem on RNN Multi GPU was the shape of tensors fed to RNN decoder.   
DataParallel requires all input tensors have the `batch_size` dimension at the same position (i.e. 0th position.) But `decoder_hidden` originally had the shape of `(num_layers, batch_size, hidden_size)`, so I permuted it to `(batch_size, num_layers, hidden_size)`.

**iwslt14** de-en BLEU
|num gpu|arch.|tok.|decoding|dev|test|
|:--|:--|:--|:--|:--|:--|
|1gpu|lstm|word|greedy|27.89||
|1gpu|lstm|word|beam10|29.13|28.51|
|3gpu|lstm|word|greedy|28.30||
|3gpu|lstm|word|beam10|29.42|29.02|
|1gpu|gru|bpe|greedy|29.68||
|1gpu|gru|bpe|beam5|30.88|30.19|
|3gpu|gru|bpe|greedy|29.22||
|3gpu|gru|bpe|beam5|30.92|30.08|

I only tested on the following environment (which is different from joeynmt's requirements):
- python 3.9.1
- torch 1.7.1
- torchtext 0.8.1
- CUDA 10.2