### PR TITLE
Support for pretrained word embeddings

### DIFF
--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -86,6 +86,7 @@ model:                              # specify your model architecture here
             embedding_dim: 16       # size of embeddings
             scale: False            # scale the embeddings by sqrt of their size, default: False
             freeze: False           # if True, embeddings are not updated during training
+            load_pretrained: "my_data/train.src.embed.txt" # if given, load pretrain embedding weights from this text file
         hidden_size: 30             # size of RNN
         bidirectional: True         # use a bi-directional encoder, default: True
         dropout: 0.2                # apply dropout to the inputs to the RNN, default: 0.0
@@ -98,6 +99,7 @@ model:                              # specify your model architecture here
             embedding_dim: 16
             scale: False
             freeze: False           # if True, embeddings are not updated during training
+            load_pretrained: "my_data/train.trg.embed.txt"
         hidden_size: 30
         dropout: 0.2
         hidden_dropout: 0.2         # apply dropout to the attention vector, default: 0.0

--- a/joeynmt/data.py
+++ b/joeynmt/data.py
@@ -76,7 +76,7 @@ def load_data(data_cfg: dict, datasets: list = None)\
 
     train_data = None
     if "train" in datasets and train_path is not None:
-        logger.info("loading training data...")
+        logger.info("Loading training data...")
         train_data = TranslationDataset(path=train_path,
                                         exts=("." + src_lang, "." + trg_lang),
                                         fields=(src_field, trg_field),
@@ -106,7 +106,7 @@ def load_data(data_cfg: dict, datasets: list = None)\
     assert (train_data is not None) or (src_vocab_file is not None)
     assert (train_data is not None) or (trg_vocab_file is not None)
 
-    logger.info("building vocabulary...")
+    logger.info("Building vocabulary...")
     src_vocab = build_vocab(field="src", min_freq=src_min_freq,
                             max_size=src_max_size,
                             dataset=train_data, vocab_file=src_vocab_file)
@@ -116,14 +116,14 @@ def load_data(data_cfg: dict, datasets: list = None)\
 
     dev_data = None
     if "dev" in datasets and dev_path is not None:
-        logger.info("loading dev data...")
+        logger.info("Loading dev data...")
         dev_data = TranslationDataset(path=dev_path,
                                       exts=("." + src_lang, "." + trg_lang),
                                       fields=(src_field, trg_field))
 
     test_data = None
     if "test" in datasets and test_path is not None:
-        logger.info("loading test data...")
+        logger.info("Loading test data...")
         # check if target exists
         if os.path.isfile(test_path + "." + trg_lang):
             test_data = TranslationDataset(
@@ -135,7 +135,7 @@ def load_data(data_cfg: dict, datasets: list = None)\
                                     field=src_field)
     src_field.vocab = src_vocab
     trg_field.vocab = trg_vocab
-    logger.info("data loaded.")
+    logger.info("Data loaded.")
     return train_data, dev_data, test_data, src_vocab, trg_vocab
 
 

--- a/joeynmt/decoders.py
+++ b/joeynmt/decoders.py
@@ -324,7 +324,7 @@ class RecurrentDecoder(Decoder):
             shape (batch_size, 1, hidden_size)
         :return:
             - outputs: shape (batch_size, unroll_steps, vocab_size),
-            - hidden: last hidden state (num_layers, batch_size, hidden_size),
+            - hidden: last hidden state (batch_size, num_layers, hidden_size),
             - att_probs: attention probabilities
                 with shape (batch_size, unroll_steps, src_length),
             - att_vectors: attentional vectors

--- a/joeynmt/encoders.py
+++ b/joeynmt/encoders.py
@@ -208,7 +208,7 @@ class TransformerEncoder(Encoder):
         :param src_length: length of src inputs
             (counting tokens before padding), shape (batch_size)
         :param mask: indicates padding areas (zeros where padding), shape
-            (batch_size, src_len, embed_size)
+            (batch_size, 1, src_len)
         :return:
             - output: hidden states with
                 shape (batch_size, max_length, directions*hidden),

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -212,7 +212,7 @@ def build_model(cfg: dict = None,
     :param trg_vocab: target vocabulary
     :return: built and initialized model
     """
-    logger.info("building an encoder-decoder model...")
+    logger.info("Building an encoder-decoder model...")
     src_padding_idx = src_vocab.stoi[PAD_TOKEN]
     trg_padding_idx = trg_vocab.stoi[PAD_TOKEN]
 
@@ -287,11 +287,11 @@ def build_model(cfg: dict = None,
     pretrained_dec_embed_path = cfg["decoder"]["embeddings"].get(
         "load_pretrained", None)
     if pretrained_enc_embed_path:
-        logger.info("loading pretraind src embeddings...")
+        logger.info("Loading pretraind src embeddings...")
         model.src_embed.load_from_file(pretrained_enc_embed_path, src_vocab)
     if pretrained_dec_embed_path and not cfg.get("tied_embeddings", False):
-        logger.info("loading pretraind trg embeddings...")
-        model.src_embed.load_from_file(pretrained_dec_embed_path, trg_vocab)
+        logger.info("Loading pretraind trg embeddings...")
+        model.trg_embed.load_from_file(pretrained_dec_embed_path, trg_vocab)
 
-    logger.info("enc-dec model built.")
+    logger.info("Enc-dec model built.")
     return model

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -3,6 +3,7 @@
 Module to represents whole models
 """
 from typing import Callable
+import logging
 
 import torch.nn as nn
 from torch import Tensor
@@ -15,6 +16,8 @@ from joeynmt.decoders import Decoder, RecurrentDecoder, TransformerDecoder
 from joeynmt.constants import PAD_TOKEN, EOS_TOKEN, BOS_TOKEN
 from joeynmt.vocabulary import Vocabulary
 from joeynmt.helpers import ConfigurationError
+
+logger = logging.getLogger(__name__)
 
 
 class Model(nn.Module):
@@ -209,6 +212,7 @@ def build_model(cfg: dict = None,
     :param trg_vocab: target vocabulary
     :return: built and initialized model
     """
+    logger.info("building an encoder-decoder model...")
     src_padding_idx = src_vocab.stoi[PAD_TOKEN]
     trg_padding_idx = trg_vocab.stoi[PAD_TOKEN]
 
@@ -277,4 +281,17 @@ def build_model(cfg: dict = None,
     # custom initialization of model parameters
     initialize_model(model, cfg, src_padding_idx, trg_padding_idx)
 
+    # initialize embeddings from file
+    pretrained_enc_embed_path = cfg["encoder"]["embeddings"].get(
+        "load_pretrained", None)
+    pretrained_dec_embed_path = cfg["decoder"]["embeddings"].get(
+        "load_pretrained", None)
+    if pretrained_enc_embed_path:
+        logger.info("loading pretraind src embeddings...")
+        model.src_embed.load_from_file(pretrained_enc_embed_path, src_vocab)
+    if pretrained_dec_embed_path and not cfg.get("tied_embeddings", False):
+        logger.info("loading pretraind trg embeddings...")
+        model.src_embed.load_from_file(pretrained_dec_embed_path, trg_vocab)
+
+    logger.info("enc-dec model built.")
     return model

--- a/scripts/average_checkpoints.py
+++ b/scripts/average_checkpoints.py
@@ -57,14 +57,19 @@ def average_checkpoints(inputs: List[str]) -> dict:
             if isinstance(p, torch.HalfTensor):
                 p = p.float()
             if k not in params_dict:
-                params_dict[k] = p
+                params_dict[k] = p.clone()
+                # NOTE: clone() is needed in case of p is a shared parameter
             else:
                 params_dict[k] += p
 
     averaged_params = collections.OrderedDict()
     # v should be a list of torch Tensor.
     for k, v in params_dict.items():
-        averaged_params[k] = v / num_models
+        averaged_params[k] = v
+        if averaged_params[k].is_floating_point():
+            averaged_params[k].div_(num_models)
+        else:
+            averaged_params[k] //= num_models
     new_state['model_state'] = averaged_params
     return new_state
 

--- a/test/unit/test_transformer_encoder.py
+++ b/test/unit/test_transformer_encoder.py
@@ -38,7 +38,7 @@ class TestTransformerEncoder(TensorTestCase):
 
         # no padding, no mask
         x_length = torch.Tensor([time_dim] * batch_size).int()
-        mask = torch.ones([batch_size, time_dim, 1]) == 1
+        mask = torch.ones([batch_size, 1, time_dim]) == 1
 
         output, hidden = encoder(x, x_length, mask)
 


### PR DESCRIPTION
- typo fix
- bug fix: scripts/average_checkpoints.py
- #112 load pretrained embeddings from file

--- 
- pretrained embeddings file has to have the format:
   Example:
   ```
   2 5
   the -0.0230 -0.0264  0.0287  0.0171  0.1403
   at -0.0395 -0.1286  0.0275  0.0254 -0.0932
   ``` 
    - the first line should have two integers: vocabulary size and dimension
    - each line should contain word and embedding weights separated by spaces.
    - dimension has to match with config (`config["model"]["encoder"]["embeddings"]["embedding_dim"]`)
- I tested `configs/iwslt_deen_bahdanau.yaml` with pretrained embeddings created as follows:
  - I used [fasttext](https://github.com/facebookresearch/fastText/). clone the repo and install it. (The file format described above is more or less conventional across frameworks, though. You can use i.e. [gensim](https://github.com/RaRe-Technologies/gensim) instead.)
  - download pretrained models and reduce the dimension
     ```
     $ cd fastText
     $ ./download_model.py en         # will download cc.en.300.bin
     $ ./download_model.py de         # will download cc.de.300.bin
     $ ./reduce_model.py cc.en.300.bin 256         # will create cc.de.256.bin
     $ ./reduce_model.py cc.de.300.bin 256         # will create cc.de.256.bin
     ```
  - apply to the train data and add headers
     ```
     $ cd test/data/iwslt14_deen/      # data dir
     $ fasttext print-word-vectors cc.en.256.bin < train.en > train.en.embed
     $ fasttext print-word-vectors cc.de.256.bin < train.de > train.de.embed
     $ wc -l train.en.embed
     3191644 train.en.embed
     $ wc -l train.de.embed
     3022820 train.de.embed
     $ echo "3191644 256" | cat - train.en.embed > train.en.embed.txt
     $ echo "3022820 256" | cat - train.de.embed > train.de.embed.txt
     ```
     - I haven't checked any tokenization issue. ideally, you should use the same tokenization method as the pretrained models.
     - for joined vocabulary, you can just concatenate these txt files (only one header line, though!)
  - then put this file path to the `config.yaml`
     ```yaml
     model:
        encoder:
            embeddings:
                embedding_dim: 256
                load_pretrained: "test/data/iwslt14_deen/train.de.embed.txt"
        decoder:
            embeddings:
                embedding_dim: 256
                load_pretrained: "test/data/iwslt14_deen/train.en.embed.txt"
     ```
- Note that the weights will be overwitten if you specify `config["training"]["load_model"]` and the model has embeddings layers.

- BLEU `configs/iwslt_deen_bahdanau.yaml` (beam size = 10)  
   ||dev|test|
   |:-|:-|:-|
   |w/o pretrained embeddings|30.13|29.40|
   |with pretrained embeddings|29.87|29.45|

   
![learning_curves](https://user-images.githubusercontent.com/5838079/105525447-682b5780-5ce1-11eb-8f9e-f09538f2e3bf.png)
