### PR TITLE
Updated link to iwslt14 data in preprocessing scripts.

### DIFF
--- a/scripts/get_iwslt14_bpe.sh
+++ b/scripts/get_iwslt14_bpe.sh
@@ -11,7 +11,7 @@ SCRIPTS=${MOSES}/scripts
 TOKENIZER=${SCRIPTS}/tokenizer/tokenizer.perl
 LC=${SCRIPTS}/tokenizer/lowercase.perl
 CLEAN=${SCRIPTS}/training/clean-corpus-n.perl
-URL="https://wit3.fbk.eu/archive/2014-01/texts/de/en/de-en.tgz"
+URL="http://dl.fbaipublicfiles.com/fairseq/data/iwslt14/de-en.tgz"
 GZ=de-en.tgz
 
 merge_ops=32000

--- a/scripts/get_iwslt14_sp.sh
+++ b/scripts/get_iwslt14_sp.sh
@@ -11,7 +11,7 @@ SCRIPTS=${MOSES}/scripts
 TOKENIZER=${SCRIPTS}/tokenizer/tokenizer.perl
 LC=${SCRIPTS}/tokenizer/lowercase.perl
 CLEAN=${SCRIPTS}/training/clean-corpus-n.perl
-URL="https://wit3.fbk.eu/archive/2014-01/texts/de/en/de-en.tgz"
+URL="http://dl.fbaipublicfiles.com/fairseq/data/iwslt14/de-en.tgz"
 GZ=de-en.tgz
 
 vocab_size=32000


### PR DESCRIPTION
This change updates the links in the get_iwslt14* preprocessing scripts because the current link is broken. I've changed them to point to a facebook hosted verison of the de-en.tgz file that they use for fairseq and run the get_iwslt14_bpe.sh script to check that it still works. Output on the test.bpe.32000.{en|de} files looked okay.