### PR TITLE
Skip tests after training

### DIFF
--- a/joeynmt/__main__.py
+++ b/joeynmt/__main__.py
@@ -23,10 +23,13 @@ def main():
     ap.add_argument("--save_attention", action="store_true",
                     help="save attention visualizations")
 
+    ap.add_argument("-t", "--skip_test", action="store_true",
+                    help="Skip test after training")
+
     args = ap.parse_args()
 
     if args.mode == "train":
-        train(cfg_file=args.config_path)
+        train(cfg_file=args.config_path, skip_test=args.skip_test)
     elif args.mode == "test":
         test(cfg_file=args.config_path, ckpt=args.ckpt,
              output_path=args.output_path, save_attention=args.save_attention)

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -751,11 +751,12 @@ class TrainManager:
             return is_best
 
 
-def train(cfg_file: str) -> None:
+def train(cfg_file: str, skip_test: bool = False) -> None:
     """
     Main training function. After training, also test on test data if given.
 
     :param cfg_file: path to configuration yaml file
+    :param skip_test: whether a test should be run or not after training
     """
     cfg = load_config(cfg_file)
 
@@ -802,21 +803,22 @@ def train(cfg_file: str) -> None:
     # train the model
     trainer.train_and_validate(train_data=train_data, valid_data=dev_data)
 
-    # predict with the best model on validation and test
-    # (if test data is available)
-    ckpt = "{}/{}.ckpt".format(model_dir, trainer.stats.best_ckpt_iter)
-    output_name = "{:08d}.hyps".format(trainer.stats.best_ckpt_iter)
-    output_path = os.path.join(model_dir, output_name)
-    datasets_to_test = {
-        "dev": dev_data,
-        "test": test_data,
-        "src_vocab": src_vocab,
-        "trg_vocab": trg_vocab
-    }
-    test(cfg_file,
-         ckpt=ckpt,
-         output_path=output_path,
-         datasets=datasets_to_test)
+    if not skip_test:
+        # predict with the best model on validation and test
+        # (if test data is available)
+        ckpt = "{}/{}.ckpt".format(model_dir, trainer.stats.best_ckpt_iter)
+        output_name = "{:08d}.hyps".format(trainer.stats.best_ckpt_iter)
+        output_path = os.path.join(model_dir, output_name)
+        datasets_to_test = {
+            "dev": dev_data,
+            "test": test_data,
+            "src_vocab": src_vocab,
+            "trg_vocab": trg_vocab
+        }
+        test(cfg_file,
+             ckpt=ckpt,
+             output_path=output_path,
+             datasets=datasets_to_test)
 
 
 if __name__ == "__main__":

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -819,7 +819,8 @@ def train(cfg_file: str, skip_test: bool = False) -> None:
              ckpt=ckpt,
              output_path=output_path,
              datasets=datasets_to_test)
-
+    else:
+        logger.info("Skipping test after training")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser('Joey-NMT')


### PR DESCRIPTION
The default behavior of JoeyNMT is to test an engine after the training is finished. However, some users may want to test it later. 

The `--skip_test` argument is added. This argument prevents the test phase from being launched after the training finishes.