### PR TITLE
Always use encoding="utf-8" with open

### DIFF
--- a/joeynmt/data.py
+++ b/joeynmt/data.py
@@ -223,7 +223,7 @@ class MonoDataset(Dataset):
             # Because the file can be stdin which doesn't need to be opened,
             # easier not to use with here.
             # pylint: disable=consider-using-with
-            src_file = open(src_path)
+            src_file = open(src_path, encoding="utf-8")
 
         examples = []
         for src_line in src_file:

--- a/joeynmt/data.py
+++ b/joeynmt/data.py
@@ -220,6 +220,9 @@ class MonoDataset(Dataset):
             src_file = path
         else:
             src_path = os.path.expanduser(path + ext)
+            # Because the file can be stdin which doesn't need to be opened,
+            # easier not to use with here.
+            # pylint: disable=consider-using-with
             src_file = open(src_path)
 
         examples = []

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -175,7 +175,7 @@ def load_config(path="configs/default.yaml") -> dict:
     :param path: path to YAML configuration file
     :return: configuration dictionary
     """
-    with open(path, 'r') as ymlfile:
+    with open(path, 'r', encoding="utf-8") as ymlfile:
         cfg = yaml.safe_load(ymlfile)
     return cfg
 

--- a/joeynmt/prediction.py
+++ b/joeynmt/prediction.py
@@ -394,7 +394,7 @@ def translate(cfg_file: str,
         tmp_name = "tmp"
         tmp_suffix = ".src"
         tmp_filename = tmp_name+tmp_suffix
-        with open(tmp_filename, "w") as tmp_file:
+        with open(tmp_filename, "w", encoding="utf-8") as tmp_file:
             tmp_file.write("{}\n".format(line))
 
         test_data = MonoDataset(path=tmp_name, ext=tmp_suffix,

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -653,7 +653,7 @@ class TrainManager:
         if current_lr < self.learning_rate_min:
             self.stats.stop = True
 
-        with open(self.valid_report_file, 'a') as opened_file:
+        with open(self.valid_report_file, 'a', encoding="utf-8") as opened_file:
             opened_file.write(
                 "Steps: {}\tLoss: {:.5f}\tPPL: {:.5f}\t{}: {:.5f}\t"
                 "LR: {:.8f}\t{}\n".format(self.stats.steps, valid_loss,
@@ -717,7 +717,8 @@ class TrainManager:
         """
         current_valid_output_file = "{}/{}.hyps".format(self.model_dir,
                                                         self.stats.steps)
-        with open(current_valid_output_file, 'w') as opened_file:
+        with open(current_valid_output_file, 'w', encoding="utf-8") \
+                as opened_file:
             for hyp in hypotheses:
                 opened_file.write("{}\n".format(hyp))
 

--- a/joeynmt/vocabulary.py
+++ b/joeynmt/vocabulary.py
@@ -58,7 +58,7 @@ class Vocabulary:
         :param file: path to file where the vocabulary is loaded from
         """
         tokens = []
-        with open(file, "r") as open_file:
+        with open(file, "r", encoding='utf-8') as open_file:
             for line in open_file:
                 tokens.append(line.strip("\n"))
         self._from_list(tokens)
@@ -72,7 +72,7 @@ class Vocabulary:
 
         :param file: path to file where the vocabulary is written
         """
-        with open(file, "w") as open_file:
+        with open(file, "w", encoding="utf-8") as open_file:
             for t in self.itos:
                 open_file.write("{}\n".format(t))
 

--- a/scripts/generate_copy_task.py
+++ b/scripts/generate_copy_task.py
@@ -25,7 +25,7 @@ def save_samples(samples,
                  prefix="train", ext="src", reverse=False):
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    with open(os.path.join(output_dir, prefix + "." + ext), mode="w") as f:
+    with open(os.path.join(output_dir, prefix + "." + ext), mode="w", encoding="utf-8") as f:
         for sample in samples:
             sample = sample[::-1] if reverse else sample
             f.write(sample_to_str(sample) + "\n")

--- a/scripts/generate_reverse_task.py
+++ b/scripts/generate_reverse_task.py
@@ -19,7 +19,7 @@ def sample_to_str(sample):
 
 
 def save_samples(samples, prefix="train", ext="src", reverse=False):
-    with open(prefix + "." + ext, mode="w") as f:
+    with open(prefix + "." + ext, mode="w", encoding="utf-8") as f:
         for sample in samples:
             sample = sample[::-1] if reverse else sample
             f.write(sample_to_str(sample) + "\n")

--- a/scripts/plot_validations.py
+++ b/scripts/plot_validations.py
@@ -19,7 +19,7 @@ def read_vfiles(vfiles):
     for vfile in vfiles:
         model_name = vfile.split("/")[-2] if "//" not in vfile \
             else vfile.split("/")[-3]
-        with open(vfile, "r") as validf:
+        with open(vfile, "r", encoding="utf-8") as validf:
             steps = {}
             for line in validf:
                 entries = line.strip().split()

--- a/test/unit/test_vocabulary.py
+++ b/test/unit/test_vocabulary.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import unittest
 import os
 
@@ -9,7 +10,7 @@ class TestVocabulary(unittest.TestCase):
         self.file = "test/data/toy/train.de"
         sent = "Die Wahrheit ist, dass die Titanic – obwohl sie alle " \
                "Kinokassenrekorde bricht – nicht gerade die aufregendste " \
-               "Geschichte vom Meer ist."
+               "Geschichte vom Meer ist. GROẞ"  # ẞ (in uppercase) requires Unicode
         self.word_list = sent.split()  # only unique tokens
         self.char_list = list(sent)
         self.temp_file_char = "tmp.src.char"
@@ -23,12 +24,13 @@ class TestVocabulary(unittest.TestCase):
         self.assertEqual(len(self.char_vocab)-len(self.char_vocab.specials),
                          len(set(self.char_list)))
         expected_char_itos = ['<unk>', '<pad>', '<s>', '</s>',
-                              ' ', ',', '.', 'D', 'G', 'K', 'M', 'T', 'W', 'a',
-                              'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'k', 'l',
-                              'm', 'n', 'o', 'r', 's', 't', 'u', 'v', 'w', '–']
+                              ' ', ',', '.', 'D', 'G', 'K', 'M', 'O', 'R', 'T', 'W',
+                              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'k', 'l',
+                              'm', 'n', 'o', 'r', 's', 't', 'u', 'v', 'w', 'ẞ', '–']
+
         self.assertEqual(self.char_vocab.itos, expected_char_itos)
         expected_word_itos = ['<unk>', '<pad>', '<s>', '</s>',
-                              'Die', 'Geschichte', 'Kinokassenrekorde', 'Meer',
+                              'Die', 'GROẞ', 'Geschichte', 'Kinokassenrekorde', 'Meer',
                               'Titanic', 'Wahrheit', 'alle', 'aufregendste',
                               'bricht', 'dass', 'die', 'gerade', 'ist,', 'ist.',
                               'nicht', 'obwohl', 'sie', 'vom', '–']
@@ -49,5 +51,7 @@ class TestVocabulary(unittest.TestCase):
     def testIsUnk(self):
         self.assertTrue(self.word_vocab.is_unk("BLA"))
         self.assertFalse(self.word_vocab.is_unk("Die"))
+        self.assertFalse(self.word_vocab.is_unk("GROẞ"))
         self.assertTrue(self.char_vocab.is_unk("x"))
         self.assertFalse(self.char_vocab.is_unk("d"))
+        self.assertFalse(self.char_vocab.is_unk("ẞ"))


### PR DESCRIPTION
While many parts of the codebase explicitly set the encoding when opening files, some rely on the default encoding and don't specify it. This goes unnoticed generally unless opening files on Windows, which will typically result in Windows-1252 encoding (or whatever the user's default codepage is) being used which will crash when Unicode data is encountered.

This PR does the following:
1. Adds a test to vocabulary.py that includes some Unicode data  to recreate the crash caused by using default encoding with Unicode data. If running this test without including the subsequent fix, you can recreate the crash outside of Windows by using `LANG=en_US.US-ASCII pytest test/unit/test_vocabulary.py`.
2. Changes all the code under joeynmt/, scripts/, and tests/ to always set the encoding to "utf-8" when opening files to match the rest of the codebase.
3. (Minor) Suppress a Pylint warning about `with` that broke CI (probably a warning in a newer version of Pylint; CI was broken when I reran it on the current master before any changes).

After introducing this change, tests pass on MacOS, Linux, and Windows. (However, Windows is complicated; a dependency is broken and to fix it you need to use Python 3.8 and `pip install pywin32==225` to fix it.) I looked at adding MacOS and Windows to Travis but it's going to be a fair amount of work since the standard Python Travis environment isn't available on either.

There is a potential issue this doesn't address: MonoDataset can read from stdin, which isn't guaranteed to have a specific encoding. This is a little awkward to address and requires more testing, so I didn't address it for now.

(About the specific word "GROẞ" used to add Unicode to the vocab tests: as the existing data was German, I just wanted a German word that actually needed Unicode to be encoded correctly, and ẞ as a capital letter has that property.)