### PR TITLE
added eps=0.0 parameter to plateau learning rate scheduler.

### DIFF
--- a/joeynmt/builders.py
+++ b/joeynmt/builders.py
@@ -142,6 +142,7 @@ def build_scheduler(config: dict, optimizer: Optimizer, scheduler_mode: str,
                                           mode=scheduler_mode,
                                           verbose=False,
                                           threshold_mode='abs',
+                                          eps=0.0,
                                           factor=config.get(
                                               "decrease_factor", 0.1),
                                           patience=config.get("patience", 10))


### PR DESCRIPTION
This fixed the bug that the learning rate wasn't reduced  when the difference between current and the reduced learning rate was less than 1e-08 (the default eps value). A consequence of this behavior was that joey didn't stop early, especially when the min learning rate was set to a low value (like 1e-08 in my case). I don't know if a similar behavior occurs for other learning rate schedulers as well. 