### PR TITLE
Move trg_length in batch to device

### DIFF
--- a/joeynmt/batch.py
+++ b/joeynmt/batch.py
@@ -85,6 +85,7 @@ class Batch:
         if self.has_trg:
             self.trg_input = self.trg_input.to(device)
             self.trg = self.trg.to(device)
+            self.trg_length = self.trg_length.to(device)
             self.trg_mask = self.trg_mask.to(device)
 
     def normalize(


### PR DESCRIPTION
When running the `reverse` tutorial example with `use_cuda=True`, I get the following error:
```
RuntimeError: indices should be either on the CPU or on the same device as the indexed tensor (CPU)
```
occurring on line `152` in `batch.py`.

To fix this, I think we need to move the `trg_length` also to the correct device in `make_cuda` in `batch.py`.