### PR TITLE
fix unittest #205

### DIFF
--- a/joeynmt/datasets.py
+++ b/joeynmt/datasets.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 import torch
-
 from torch.utils.data import (
     BatchSampler,
     DataLoader,

--- a/joeynmt/hub_interface.py
+++ b/joeynmt/hub_interface.py
@@ -3,18 +3,17 @@ from functools import partial
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Union
 
+import numpy as np
 from torch import nn
 
-import numpy as np
-
-from joeynmt.datasets import build_dataset, BaseDataset, StreamDataset
+from joeynmt.datasets import BaseDataset, StreamDataset, build_dataset
 from joeynmt.helpers import (
     load_checkpoint,
     load_config,
     parse_train_args,
     resolve_ckpt_path,
 )
-from joeynmt.model import build_model, Model
+from joeynmt.model import Model, build_model
 from joeynmt.prediction import predict
 from joeynmt.tokenizers import build_tokenizer
 from joeynmt.vocabulary import build_vocab

--- a/joeynmt/prediction.py
+++ b/joeynmt/prediction.py
@@ -11,10 +11,10 @@ from itertools import zip_longest
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-from tqdm import tqdm
 import numpy as np
 import torch
 from torch.utils.data import Dataset
+from tqdm import tqdm
 
 from joeynmt.data import load_data
 from joeynmt.datasets import StreamDataset, build_dataset

--- a/joeynmt/tokenizers.py
+++ b/joeynmt/tokenizers.py
@@ -50,6 +50,7 @@ class BasicTokenizer:
                 from sacremoses import (  # pylint: disable=import-outside-toplevel
                     MosesDetokenizer, MosesPunctNormalizer, MosesTokenizer,
                 )
+
                 # sacremoses package has to be installed.
                 # https://github.com/alvations/sacremoses
             except ImportError as e:
@@ -252,7 +253,7 @@ class SubwordNMTTokenizer(BasicTokenizer):
         self.dropout: float = kwargs.get("dropout", 0.0)
 
         bpe_parser = apply_bpe.create_parser()
-        for action in bpe_parser._actions: # workaround to ensure utf8 encoding
+        for action in bpe_parser._actions:  # workaround to ensure utf8 encoding
             if action.dest == "codes":
                 action.type = argparse.FileType('r', encoding='utf8')
         bpe_args = bpe_parser.parse_args(

--- a/joeynmt/tokenizers.py
+++ b/joeynmt/tokenizers.py
@@ -2,6 +2,7 @@
 """
 Tokenizer module
 """
+import argparse
 import logging
 import shutil
 from pathlib import Path
@@ -244,13 +245,18 @@ class SubwordNMTTokenizer(BasicTokenizer):
         super().__init__(level, lowercase, normalize, max_length, min_length, **kwargs)
         assert self.level == "bpe"
 
-        self.codes: Path = Path(kwargs["codes"])
-        assert self.codes.is_file(), f"codes file {self.codes} not found."
+        codes_file = Path(kwargs["codes"])
+        assert codes_file.is_file(), f"codes file {codes_file} not found."
 
         self.separator: str = kwargs.get("separator", "@@")
+        self.dropout: float = kwargs.get("dropout", 0.0)
+
         bpe_parser = apply_bpe.create_parser()
+        for action in bpe_parser._actions: # workaround to ensure utf8 encoding
+            if action.dest == "codes":
+                action.type = argparse.FileType('r', encoding='utf8')
         bpe_args = bpe_parser.parse_args(
-            ["--codes", kwargs["codes"], "--separator", self.separator])
+            ["--codes", codes_file.as_posix(), "--separator", self.separator])
         self.bpe = apply_bpe.BPE(
             bpe_args.codes,
             bpe_args.merges,
@@ -258,7 +264,7 @@ class SubwordNMTTokenizer(BasicTokenizer):
             None,
             bpe_args.glossaries,
         )
-        self.dropout: float = kwargs.get("dropout", 0.0)
+        self.codes: Path = bpe_args.codes
 
     def __call__(self, raw_input: str, is_train: bool = False) -> List[str]:
         """Tokenize"""

--- a/scripts/discord_joey.py
+++ b/scripts/discord_joey.py
@@ -20,9 +20,8 @@ cf.)
 """
 
 import discord
-from discord import SlashCommandGroup, option
-
 import torch
+from discord import SlashCommandGroup, option
 
 TOKEN = "your-bot-token-here"  # replace with your bot token
 guild = 123456789  # replace with your guild ID

--- a/test/unit/test_model_init.py
+++ b/test/unit/test_model_init.py
@@ -1,6 +1,5 @@
-import unittest
-
 import copy
+import unittest
 
 import torch
 from torch import nn

--- a/test/unit/test_tokenizer.py
+++ b/test/unit/test_tokenizer.py
@@ -1,8 +1,6 @@
 import random
 import unittest
 
-import sentencepiece as spm
-
 from joeynmt.data import load_data
 from joeynmt.tokenizers import (
     BasicTokenizer,
@@ -39,7 +37,6 @@ class TestTokenizer(unittest.TestCase):
         # set seed
         seed = 42
         random.seed(seed)
-        spm.set_random_generator_seed(seed)
 
     def testBasicTokenizer(self):
         # first valid example from the training set after filtering
@@ -152,10 +149,12 @@ class TestTokenizer(unittest.TestCase):
             detokenized = tokenizer.post_process(tokenized)
             self.assertEqual(detokenized, expected[lang]['detokenized'])
 
-            tokenizer.nbest_size = -1
-            tokenizer.alpha = 0.8
-            dropout = tokenizer(detokenized, is_train=True)
-            self.assertEqual(dropout, expected[lang]['dropout'])
+            # we cannot set a random seed for sampling.
+            # cf) https://github.com/google/sentencepiece/issues/609
+            #tokenizer.nbest_size = -1
+            #tokenizer.alpha = 0.8
+            #dropout = tokenizer(detokenized, is_train=True)
+            #self.assertEqual(dropout, expected[lang]['dropout'])
 
     def testSubwordNMTTokenizer(self):
         cfg = self.data_cfg.copy()

--- a/test/unit/test_tokenizer.py
+++ b/test/unit/test_tokenizer.py
@@ -151,10 +151,10 @@ class TestTokenizer(unittest.TestCase):
 
             # we cannot set a random seed for sampling.
             # cf) https://github.com/google/sentencepiece/issues/609
-            #tokenizer.nbest_size = -1
-            #tokenizer.alpha = 0.8
-            #dropout = tokenizer(detokenized, is_train=True)
-            #self.assertEqual(dropout, expected[lang]['dropout'])
+            # tokenizer.nbest_size = -1
+            # tokenizer.alpha = 0.8
+            # dropout = tokenizer(detokenized, is_train=True)
+            # self.assertEqual(dropout, expected[lang]['dropout'])
 
     def testSubwordNMTTokenizer(self):
         cfg = self.data_cfg.copy()

--- a/test/unit/test_weight_tying.py
+++ b/test/unit/test_weight_tying.py
@@ -1,6 +1,5 @@
-import unittest
-
 import copy
+import unittest
 
 import torch
 


### PR DESCRIPTION
- remove sentencepiece sampling from tokenizer unittest
- workaround to ensure utf8 encoding in subwird-nmt codes file