### PR TITLE
RFC: Add early stopping for all LR schedulers based on validation score improvements

### DIFF
--- a/configs/iwslt14_deen_bpe_early_stopping.yaml
+++ b/configs/iwslt14_deen_bpe_early_stopping.yaml
@@ -1,0 +1,112 @@
+name: "transformer_iwslt14_deen_bpe"
+joeynmt_version: "2.0.0"
+
+data:
+    train: "test/data/iwslt14/train"
+    dev: "test/data/iwslt14/valid"
+    test: "test/data/iwslt14/test"
+    dataset_type: "plain"
+    src:
+        lang: "de"
+        max_length: 62
+        lowercase: True
+        normalize: False
+        level: "bpe"
+        voc_min_freq: 1
+        voc_file: "test/data/iwslt14/bpe_vocab.txt"
+        tokenizer_type: "subword-nmt"
+        tokenizer_cfg:
+            num_merges: 32000
+            codes: "test/data/iwslt14/bpe.32000"
+            pretokenizer: "none"
+    trg:
+        lang: "en"
+        max_length: 62
+        lowercase: True
+        normalize: False
+        level: "bpe"
+        voc_min_freq: 1
+        voc_file: "test/data/iwslt14/bpe_vocab.txt"
+        tokenizer_type: "subword-nmt"
+        tokenizer_cfg:
+            num_merges: 32000
+            codes: "test/data/iwslt14/bpe.32000"
+            pretokenizer: "none"
+
+testing:
+    n_best: 1
+    beam_size: 5
+    beam_alpha: 1.0
+    batch_size: 1024
+    batch_type: "token"
+    max_output_length: 100
+    eval_metrics: ["bleu"]
+    return_prob: "none"
+    return_attention: False
+    sacrebleu_cfg:
+        tokenize: "13a"
+        lowercase: True
+
+training:
+    #load_model: "models/transformer_iwslt14_deen_bpe/best.ckpt"
+    random_seed: 42
+    optimizer: "adam"
+    normalization: "tokens"
+    adam_betas: [0.9, 0.999]
+    scheduling: "warmupinversesquareroot"
+    warmup: 4000
+    loss: "crossentropy"
+    learning_rate: 0.0005
+    learning_rate_min: 0.00000001
+    validation_step_patience: 5
+    weight_decay: 0.0
+    label_smoothing: 0.1
+    batch_size: 4096
+    batch_type: "token"
+    early_stopping_metric: "bleu"
+    epochs: 100
+    validation_freq: 1000
+    logging_freq: 100
+    model_dir: "models/transformer_iwslt14_deen_bpe"
+    overwrite: False
+    shuffle: True
+    use_cuda: True
+    print_valid_sents: [0, 1, 2, 3, 4]
+    keep_best_ckpts: 5
+
+model:
+    initializer: "xavier_uniform"
+    embed_initializer: "xavier_uniform"
+    embed_init_gain: 1.0
+    init_gain: 1.0
+    bias_initializer: "zeros"
+    tied_embeddings: True
+    tied_softmax: True
+    encoder:
+        type: "transformer"
+        num_layers: 6
+        num_heads: 4
+        embeddings:
+            embedding_dim: 256
+            scale: True
+            dropout: 0.
+        # typically ff_size = 4 x hidden_size
+        hidden_size: 256
+        ff_size: 1024
+        dropout: 0.3
+        layer_norm: "pre"
+        activation: "relu"
+    decoder:
+        type: "transformer"
+        num_layers: 6
+        num_heads: 4
+        embeddings:
+            embedding_dim: 256
+            scale: True
+            dropout: 0.
+        # typically ff_size = 4 x hidden_size
+        hidden_size: 256
+        ff_size: 1024
+        dropout: 0.3
+        layer_norm: "pre"
+        activation: "relu"

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -269,6 +269,7 @@ def parse_train_args(cfg: Dict, mode: str = "training") -> Tuple:
         raise ConfigurationError(
             "Invalid setting for `early_stopping_metric`. "
             "Valid options: {`acc`, `loss`, `ppl`, `bleu`, `chrf`}.")
+    validation_step_patience = cfg.get("validation_step_patience", -1)
 
     # data & batch handling
     seed: int = cfg.get("random_seed", 42)
@@ -302,6 +303,7 @@ def parse_train_args(cfg: Dict, mode: str = "training") -> Tuple:
         validation_freq,
         log_valid_sents,
         early_stopping_metric,
+        validation_step_patience,
         seed,
         shuffle,
         epochs,


### PR DESCRIPTION
This is an example implementation to address #215 , which allows early stopping based on validation metric improvements regardless of the learning rate scheduler used. Prior to this, only the plateau scheduler could trigger early stopping, and that was based on it reducing the learning rate of the optimizer to below the min_lr setting. This change allows for specifying a threshold of successive validation runs, which if no improvement on the validation score is observed, ends training early.

An example training config is also included (`configs/iwslt14_deen_bpe_early_stopping.yaml`).